### PR TITLE
PCI-DSS 4.0 is out

### DIFF
--- a/xml/art_security_pcidss.xml
+++ b/xml/art_security_pcidss.xml
@@ -113,8 +113,8 @@
    Council (SSC), which was founded by the five major credit card brands, Visa,
    MasterCard, American Express, Discover, and JCB. In December 2004, &pcidssa;
    1.0 was released to address the growing threat of online credit card
-   fraud. The current version, &pcidssa; version 3.2, has been available since
-   April 2016.
+   fraud. The current version, &pcidssa; version 4.0, has been available since
+   March 2022.
   </para>
 
   <orderedlist>


### PR DESCRIPTION
### PR creator: Description

We claim that PCI-DSS 3.2 is the current version, but 4.0 has been released end of March, see https://blog.pcisecuritystandards.org/pci-dss-v4-0-resource-hub

This PR only updates the version number and release date but no content whatsoever. The [wikipedia article](https://en.wikipedia.org/wiki/Payment_Card_Industry_Data_Security_Standard#History) suggests more work (firewall, 2FA) is necessary.