### PR TITLE
Specific K3s version

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -398,11 +398,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         <stepalternatives>
           <step>
             <para>Installing as user &rootuser;</para>
-            <screen>&prompt.root;curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_SELINUX_RPM=true sh</screen>
+            <screen>&prompt.root;curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=v1.24.6+k3s1 sh</screen>
           </step>
           <step>
             <para>Installing as non-&rootuser; user:</para>
-            <screen>&prompt.user;curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_SELINUX_RPM=true sh -s - --write-kubeconfig-mode 644</screen>
+            <screen>&prompt.user;curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_SELINUX_RPM=true INSTALL_K3S_VERSION=v1.24.6+k3s1 sh -s - --write-kubeconfig-mode 644</screen>
           </step>
         </stepalternatives>
       </step>


### PR DESCRIPTION
Specify K3s version v1.24.6+k3s1 in the K3s installation command (there is a issue with latest version of K3s (v1.25.3+k3s1) and if you issue the installation of K3s without specifying a version, the latter installation of Trento Server fails (see https://bugzilla.suse.com/show_bug.cgi?id=1205171).

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

