### PR TITLE
Add missing Docmanager tags for Container Guide

### DIFF
--- a/container-guide/adoc/book-container-docinfo.xml
+++ b/container-guide/adoc/book-container-docinfo.xml
@@ -1,5 +1,11 @@
 <date><?dbtimestamp format="B d, Y"?></date>
 <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-<dm:editurl>https://github.com/SUSE/doc-unversioned/edit/main/container-guide/xml/</dm:editurl>
-<dm:translation>yes</dm:translation>
+  <dm:bugtracker>
+     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+     <dm:component>Container</dm:component>
+     <dm:product>Documentation</dm:product>
+     <dm:assignee>dmitri.popov@suse.com</dm:assignee>
+  </dm:bugtracker>
+  <dm:editurl>https://github.com/SUSE/doc-unversioned/edit/main/container-guide/xml/</dm:editurl>
+  <dm:translation>yes</dm:translation>
 </dm:docmanager>

--- a/container-guide/adoc/book-container.adoc
+++ b/container-guide/adoc/book-container.adoc
@@ -1,6 +1,8 @@
 include::attributes-generic.adoc[]
 include::attributes-product.adoc[]
 
+:docinfo:
+
 [container-guide]
 = Container Guide
 


### PR DESCRIPTION
### PR creator: Description

The Container Guide misses some Docmanager tags for Bugzilla. This leads to broken "Report bug" link.

If we want to use Bugzilla, there is a product "Documentation". However, you can't select "Container".

### PR creator: Are there any relevant issues/feature requests?

* SD-103231 (request new "Container" component in Bugzilla)
