### PR TITLE
Add Trento Server requirement for K3s

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -218,8 +218,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
       &t.agent;s. </para>
     <section xml:id="sec-trento-server-requirements">
       <title>&t.server; requirements</title>
-      <para> Running all the &t.server; components requires a minimum of 2GB of RAM, 
-       two CPU cores and 64GB of storage. </para>
+      <para> Running all the &t.server; components requires a minimum of 2GB of RAM,
+        two CPU cores and 64GB of storage.
+        When usng K3s, storage should be provided under <filename>/var/lib/rancher/k3s</filename>,
+        with at least 64 GB.
+      </para>
       <para>
         The &t.server; and the &t.agent;s requires a public SSH key exchange before
         they can start their communication. To create the public and private SSH keys,


### PR DESCRIPTION
### PR creator: Description

Add sentence for the section "Trento Server requirements" when using K3s.

Here is the relevant section as HTML screenshot:

![Screenshot_20221116_151416](https://user-images.githubusercontent.com/1312925/202203559-eaca9002-235c-4c60-abd3-f7adf1606893.png)


### PR creator: Are there any relevant issues/feature requests?

Taken from https://confluence.suse.com/display/TRNT/2022-11-16+Trento+Documentation
