### PR TITLE
K8s based on x86_64 architecture

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -169,7 +169,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             <title>&k8s;:</title>
             <para> The &t.server; runs on any current Cloud Native
               Computing Foundation (CNCF)-certified &k8s;
-              distributions. Depending on your background and
+              distributions based on a x86_64 architecture. Depending on your background and
               needs, &suse; supports several usage scenarios:
             </para>
           </formalpara>
@@ -240,7 +240,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
           <para>RKE2</para>
         </listitem>
         <listitem>
-          <para>any other CNCF-certified &k8s;</para>
+          <para>any other CNCF-certified &k8s; running on x86_64 architecture</para>
         </listitem>
       </itemizedlist>
     </section>


### PR DESCRIPTION
Trento is only supported on K8s based on a x86_64 architecture

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

