### PR TITLE
Fixes for KubeVirt doc

### DIFF
--- a/kubevirt/xml/art-kubevirt.xml
+++ b/kubevirt/xml/art-kubevirt.xml
@@ -330,8 +330,7 @@ spec:
       path: /hostDisks/sles15sp2/disk.raw
       type: Disk
       shared: true
-    name: host-disk
-    status: {}</screen>
+    name: host-disk</screen>
 
     <para>
       Applying this VMI manifest to the cluster will create a virt-launcher


### PR DESCRIPTION


### PR creator: Description

kubevirt: Fix the VMI manifest example

Remove the redundant field 'status: {}' from the manifest as it causes validation errors.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

