### PR TITLE
Change bsc component to SLE Family in SAP HA doc

### DIFF
--- a/sap-ha-support/xml/art-sap-ha-support.xml
+++ b/sap-ha-support/xml/art-sap-ha-support.xml
@@ -21,7 +21,7 @@
       <dm:bugtracker>
         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
         <dm:product>Documentation</dm:product>
-        <dm:component>Smart Docs</dm:component>
+        <dm:component>SLE Family</dm:component>
         <dm:assignee>tahlia.richardson@suse.com</dm:assignee>
       </dm:bugtracker>
       <dm:editurl>https://github.com/SUSE/doc-unversioned/edit/main/sap-ha-support/xml/</dm:editurl>


### PR DESCRIPTION
### PR creator: Description

Changed the Bugzilla component in the SAP/HA overview doc to `SLE Family`. 



