### PR TITLE
Right syntax for parameter FACTS_SERVICE_URL

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -640,7 +640,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         <itemizedlist>
           <listitem>
             <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine, where fact gathering requests are received.
-           The right syntax is amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672.</para>
+           The right syntax is <uri>amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672</uri>.</para>
           </listitem>
           <listitem>
             <para><parameter>server-url</parameter>: URL for the Trento Server (<uri>http://TRENTO_SERVER_HOSTNAME</uri>)

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -255,6 +255,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             &t.server; must be reachable via HTTP (port TCP/80) or via HTTPS (port TCP/443) if SSL is enabled, from any &t.agent; host.
           </para>
         </listitem>
+        <listitem>
+          <para>
+            &t.server; must be reachable via Advanced Message Queuing Protocol or AMQP (port TCP/5672), from any &t.agent; host.
+          </para>
+        </listitem>
          <listitem>
           <para>
             &t.server; must be able to reach the Node Exporter in the &t.agent; hosts (port TCP/9100).
@@ -634,7 +639,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </para>
         <itemizedlist>
           <listitem>
-            <para><parameter>facts-service-url</parameter>: the address of the AMQP (Advanced Message Queuing Protocol) service shared with the checks engine, where fact gathering requests are received.
+            <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine, where fact gathering requests are received.
            The right syntax is amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672.</para>
           </listitem>
           <listitem>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2157,7 +2157,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
         <itemizedlist>
           <listitem>
             <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine where fact gathering requests are received.
-           The right syntax is amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672. </para>
+           The right syntax is <uri>amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672</uri>. </para>
           </listitem>
           <listitem>
             <para><parameter>server-url</parameter>: HTTP URL for the &t.server;

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -634,7 +634,8 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </para>
         <itemizedlist>
           <listitem>
-            <para><parameter>facts-service-url</parameter>: the address of the AMQP (Advanced Message Queuing Protocol) service shared with the checks engine, where fact gathering requests are received.</para>
+            <para><parameter>facts-service-url</parameter>: the address of the AMQP (Advanced Message Queuing Protocol) service shared with the checks engine, where fact gathering requests are received.
+           The right syntax is amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672.</para>
           </listitem>
           <listitem>
             <para><parameter>server-url</parameter>: URL for the Trento Server (<uri>http://TRENTO_SERVER_HOSTNAME</uri>)
@@ -2150,7 +2151,8 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
         </para>
         <itemizedlist>
           <listitem>
-            <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine where fact gathering requests are received.</para>
+            <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine where fact gathering requests are received.
+           The right syntax is amqp://trento:trento@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672. </para>
           </listitem>
           <listitem>
             <para><parameter>server-url</parameter>: HTTP URL for the &t.server;


### PR DESCRIPTION
Right syntax for parameter FACTS_SERVICE_URL

### PR creator: Description

Right syntax for agent configuration parameter FACTS_SERVICE_URL and requirement for AMQP connectivity from the agent host to the trento server.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

