### PR TITLE
Container Guide: fix broken links

### DIFF
--- a/container-guide/adoc/containers-bci.adoc
+++ b/container-guide/adoc/containers-bci.adoc
@@ -395,7 +395,7 @@ Remove a package::
 Clean up temporary files::
   `zypper clean`
 
-For more information on using {zypper}, refer to https://documentation.suse.com/sles-15/html/{sles}-all/cha-sw-cl.html#sec-zypper.
+For more information on using {zypper}, refer to https://documentation.suse.com/sles/html/SLES-all/cha-sw-cl.html#sec-zypper.
 
 All the described commands use the `--non-interactive` flag to skip confirmations, since you cannot approve these manually during container builds. Keep in mind that you must use the flag with any command that modifies the system. Also note that `--non-interactive` is not a "yes to all" flag. Instead, `--non-interactive` confirms what is considered to be the intention of the user. For example, an installation command with the `--non-interactive` option fails if it needs to import new repository signing keys, as that is something that the user must verify themselves.
 
@@ -486,10 +486,10 @@ Step 4/4 : EXPOSE 8000
  ---> Using cache
  ---> 48b33ec590a6
 Successfully built 48b33ec590a6
- 
+
 > docker run -p 8000:8000 --rm -d 48b33ec590a6
 575ad7edf43e11c2c9474055f7f6b7a221078739fc8ce5765b0e34a0c899b46a
- 
+
 > curl localhost:8000
 Hello Green World!
 ....

--- a/container-guide/adoc/containers-orchestration.adoc
+++ b/container-guide/adoc/containers-orchestration.adoc
@@ -419,7 +419,7 @@ dc9dca018dad  docker.io/library/drupal:latest          apache2-foregroun...  4 s
 [[sec-orchestration-podman-more]]
 ==== More on {podman}
 If you want to learn more on podman and in depth instruction on how to handle pod deployment,
-please check https://docs.podman.io/en/latest/  and https://github.com/containers/podman
+please check https://docs.podman.io/en/latest/ and https://github.com/containers/podman
 
 [[sec-orchestration-kubernetes]]
 === Multi Container Host with Kubernetes

--- a/container-guide/adoc/containers-registration-repositories.adoc
+++ b/container-guide/adoc/containers-registration-repositories.adoc
@@ -6,7 +6,7 @@ include::attributes-product.adoc[]
 
 [[sec-sle-containers-module]]
 === SLE Containers Module
-As a pre-requisite to work with containers on a SUSE Linux Enterprise Server, you have to enable the {sle-containers-module}. This contains packages revolving around containers, including container engine and core container-related tools like on-premise registry. For more information about SLE Modules, please refers to https://documentation.suse.com/sles/15-SP3/html/SLES-all/article-modules.html.
+As a pre-requisite to work with containers on a SUSE Linux Enterprise Server, you have to enable the {sle-containers-module}. This contains packages revolving around containers, including container engine and core container-related tools like on-premise registry. For more information about SLE Modules, please refers to https://documentation.suse.com/sles/html/SLES-all/article-modules.html.
 
 The regular SLES subscription include {sle-containers-module} free of charge.
 


### PR DESCRIPTION
### PR creator: Description

`daps linkcheck` reported some broken links which have been fixed. In addition, turned some links into SP-independent links (as per style guide recommendation, see https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-link-to-susecom)


