### PR TITLE
Add rows for ENSA1 and 2 with SAP Web Dispatcher

### DIFF
--- a/sap-ha-support/xml/art-sap-ha-support.xml
+++ b/sap-ha-support/xml/art-sap-ha-support.xml
@@ -759,6 +759,31 @@
       <entry>Although it is possible to run Application Servers in the same cluster where ASCS/ERS
       are running, it is not recommended for easy management of the cluster.</entry>
      </row>
+     <row>
+       <entry>&sap; Web Dispatcher in cluster</entry>
+       <entry>Supported (<link xlink:href="https://www.suse.com/c/yes-sap-web-dispatcher-high-availability-on-premise-and-cloud/">Documentation</link>
+       for the <emphasis>Filesystem</emphasis> resource-based setup; not yet documented for
+       the simple mount structure)</entry>
+       <entry><para>This solution combines the following resources into one cluster resource group:</para>
+         <itemizedlist>
+           <listitem>
+             <para>
+               An &sap; instance including the <literal>sapwebdisp</literal> service
+             </para>
+           </listitem>
+           <listitem>
+             <para>
+               A file system where the &sap; instance is running
+             </para>
+           </listitem>
+           <listitem>
+             <para>
+               An IP address used by the clients of the service
+             </para>
+           </listitem>
+         </itemizedlist>
+       </entry>
+     </row>
     </tbody>
    </tgroup>
   </table>
@@ -837,6 +862,31 @@
       <entry>Supported but undocumented</entry>
       <entry>Although it is possible to run Application Servers in the same cluster where
       ASCS/ERS are running, it is not recommended for easy management of the cluster.</entry>
+     </row>
+     <row>
+       <entry>&sap; Web Dispatcher in cluster</entry>
+       <entry>Supported (<link xlink:href="https://www.suse.com/c/yes-sap-web-dispatcher-high-availability-on-premise-and-cloud/">Documentation</link>
+       for the <emphasis>Filesystem</emphasis> resource-based setup; not yet documented for
+       the simple mount structure)</entry>
+       <entry><para>This solution combines the following resources into one cluster resource group:</para>
+         <itemizedlist>
+           <listitem>
+             <para>
+               An &sap; instance including the <literal>sapwebdisp</literal> service
+             </para>
+           </listitem>
+           <listitem>
+             <para>
+               A file system where the &sap; instance is running
+             </para>
+           </listitem>
+           <listitem>
+             <para>
+               An IP address used by the clients of the service
+             </para>
+           </listitem>
+         </itemizedlist>
+       </entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
### PR creator: Description

Added the following row to _Table 4: Supported configurations for S/4HANA based on ABAP Platform 1809 or newer_ and _Table 5: Supported configurations for SAP NetWeaver based on ABAP Platform 1709 or older_:

![Screenshot from 2023-08-18 14-47-19](https://github.com/SUSE/doc-unversioned/assets/3069029/6af0046c-528d-4cf1-9ced-2584a58a2829)


### PR creator: Are there any relevant issues/feature requests?

* bsc#1214376
* jsc#DOCTEAM-1090

