### PR TITLE
title: use entity with correct spelling

### DIFF
--- a/container-guide/articles/Container-guide.asm.xml
+++ b/container-guide/articles/Container-guide.asm.xml
@@ -40,7 +40,7 @@
   </resources>
   <structure renderas="article" xml:id="container-guide" xml:lang="en">
     <merge>
-      <title>Container guide</title>
+      <title>&sle_container_guide;</title>
       <revhistory>
         <title>Changelog</title>
         <revision><revnumber>1</revnumber><date>2023-08-10</date>
@@ -66,7 +66,7 @@
         <productname version="15-GA">&sles;</productname>
         </meta>-->
       <!-- SEO and social media -->
-      <meta name="title">Container guide</meta>
+      <meta name="title">Container Guide</meta>
       <meta name="description">
        The official guide to SUSE container-related products and technologies.
      </meta>


### PR DESCRIPTION
### PR creator: Description

Update spelling of book title as agreed with @dmpop ('Container guide' ->  'Container Guide').  


### PR creator: Are there any relevant issues/feature requests?

* Fixes one of the issues mentioned in https://github.com/SUSE/doc-unversioned/pull/99

