### PR TITLE
Rename CPUs => vCPUs

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -257,7 +257,7 @@
      </row>
      <row>
       <entry>
-        CPUs
+        vCPUs
       </entry>
       <entry>
        int


### PR DESCRIPTION
SUSEConnect doesn't capture hardware CPUs, but logical or virtual CPUs (i.e., the result of sockets * cores per socket * threads per core). This PR updates the documentation to use the precise naming.

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

