### PR TITLE
Update outdated project link in  trento documentation

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2948,7 +2948,7 @@ trento-server-rabbitmq-0</screen>
         <para>Homepage: <link xlink:href="https://www.trento-project.io/"/></para>
       </listitem>
       <listitem>
-        <para>Trento project: <link xlink:href="https://github.com/trento-project/trento"/></para>
+        <para>Trento project: <link xlink:href="https://github.com/trento-project/web"/></para>
       </listitem>
     </itemizedlist>
   </section>


### PR DESCRIPTION
### Description

This pr aims to update the provided project link in chapter "**16 More information**".

The current link redirects the reader to the archived version of Trento.

This change points to Trento web, the current main part of the project, where the reader is welcomed by a README which provides a good overview over what Trento is.
