### PR TITLE
Removed the old unsupported PCI-DSS version 3.2.1 from the Compliance documentation

### DIFF
--- a/openscap/xml/article_openscap.xml
+++ b/openscap/xml/article_openscap.xml
@@ -469,11 +469,6 @@
         </listitem>
         <listitem>
           <para>
-            PCI-DSS v3.2.1 Control Baseline for &sle; 15
-          </para>
-        </listitem>
-        <listitem>
-          <para>
             PCI-DSS v4 Control Baseline for &sle; 15
           </para>
         </listitem>
@@ -552,11 +547,6 @@
         <listitem>
           <para>
             DISA STIG for &sle; 12
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            PCI-DSS v3.2.1 Control Baseline for &sle; 12
           </para>
         </listitem>
         <listitem>


### PR DESCRIPTION
### PR creator: Description

Removed the old unsupported PCI-DSS version 3.2.1 from the Compliance documentation.

### PR creator: Are there any relevant issues/feature requests?

* [jsc#DOCTEAM-1428](https://jira.suse.com/browse/DOCTEAM-1428)

> **NOTE**: For the remaining part of the JIRA issue, I will hand it over to Karl or Ornella to update the SUMA docs.

