### PR TITLE
Container Guide: add metadata

### DIFF
--- a/container-guide/articles/Container-guide.asm.xml
+++ b/container-guide/articles/Container-guide.asm.xml
@@ -64,21 +64,14 @@
       <!-- enter the platform identifier or list of comma-separated list of identifiers -->
       <meta name="architecture" content="x86_64;zseries;power;aarch64"/>
       <!-- enter product name and version -->
-      <!--<meta name="productname">
-        <productname version="ALP">&sles;</productname>
-        <productname version="15-SP5">&sles;</productname>
-        <productname version="15-SP4">&sles;</productname>
-        <productname version="15-SP3">&sles;</productname>
-        <productname version="15-SP2">&sles;</productname>
-        <productname version="15-SP1">&sles;</productname>
-        <productname version="15-GA">&sles;</productname>
-        </meta>-->
+      <meta name="productname" its:translate="no">
+        <productname version="16.0" os="sles">&productname;</productname>
+      </meta>
       <!-- SEO and social media -->
      <meta name="title">&sle_container_guide;</meta>
      <meta name="series" its:translate="no">Products &amp; Solutions</meta>
      <meta name="description" its:translate="yes">How to navigate the &sles; container ecosystem</meta>
      <meta name="social-descr" its:translate="yes">Manage containers on &slsa;</meta>
-     <meta name="category" content="Containerization"/>
      <meta name="task" its:translate="no">
       <phrase>Containerization</phrase>
       <phrase>Container Management</phrase>

--- a/container-guide/articles/Container-guide.asm.xml
+++ b/container-guide/articles/Container-guide.asm.xml
@@ -9,6 +9,7 @@
 <assembly version="5.2" xml:lang="en"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:trans="http://docbook.org/ns/transclusion"
+  xmlns:its="http://www.w3.org/2005/11/its"
   xmlns="http://docbook.org/ns/docbook">
   <resources>
     <resource xml:id="_containers-intro" href="../concepts/containers-intro.xml"/>
@@ -43,21 +44,21 @@
     <merge>
       <title>&sle_container_guide;</title>
       <revhistory>
-        <revision><revnumber>1</revnumber><date>2023-08-10</date>
+       <revision><date>2023-11-17</date>
+        <revdescription>
+         <para>
+          Add the Using Long Term Service Pack Support container images from the &suseregistry; chapter.
+         </para>
+        </revdescription>
+       </revision>
+        <revision><date>2023-08-10</date>
           <revdescription>
             <para>
-              Initial version
+              Initial version.
             </para>
           </revdescription>
         </revision>
-        <revision><revnumber>2</revnumber><date>2023-11-17</date>
-          <revdescription>
-            <para>
-              Add the Using Long Term Service Pack Support container images from the &suseregistry; chapter.
-            </para>
-          </revdescription>
-        </revision>
-      </revhistory>
+       </revhistory>
       <!-- ISO date of last update as YYYY-MM-DD -->
       <meta name="updated" content="2023-07-04"/>
       <!-- enter the platform identifier or list of comma-separated list of identifiers -->
@@ -73,15 +74,15 @@
         <productname version="15-GA">&sles;</productname>
         </meta>-->
       <!-- SEO and social media -->
-      <meta name="title">Container Guide</meta>
-      <meta name="description">
-       The official guide to SUSE container-related products and technologies.
+     <meta name="title">&sle_container_guide;</meta>
+     <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+     <meta name="description" its:translate="yes">How to navigate the &sles; container ecosystem</meta>
+     <meta name="social-descr" its:translate="yes">Manage containers on &slsa;</meta>
+     <meta name="category" content="Containerization"/>
+     <meta name="task" its:translate="yes">
+      <phrase>Containerization</phrase>
+      <phrase>Container Management</phrase>
      </meta>
-      <meta name="social-descr">
-        The official guide to SUSE container-related products and technologies.
-     </meta>
-      <!-- suitable category, comma-separated list of categories -->
-      <meta name="category" content="Containerization"/>
       <!-- Docmanager -->
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
@@ -90,7 +91,8 @@
           <dm:product>Documentation</dm:product>
           <dm:assignee>dmitri.popov@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:translation>no</dm:translation>
+        <dm:editurl>https://bugzilla.suse.com/enter_bug.cgi</dm:editurl>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <abstract>
         <para>

--- a/container-guide/articles/Container-guide.asm.xml
+++ b/container-guide/articles/Container-guide.asm.xml
@@ -79,7 +79,7 @@
      <meta name="description" its:translate="yes">How to navigate the &sles; container ecosystem</meta>
      <meta name="social-descr" its:translate="yes">Manage containers on &slsa;</meta>
      <meta name="category" content="Containerization"/>
-     <meta name="task" its:translate="yes">
+     <meta name="task" its:translate="no">
       <phrase>Containerization</phrase>
       <phrase>Container Management</phrase>
      </meta>


### PR DESCRIPTION
### PR creator: Description

Add metadata from 'Product Docs Metadata per deliverable' spreadsheet.


### PR creator: Are there any relevant issues/feature requests?

Link to our [internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation).

### Open Questions

- Do we want to treat the guide as 'Smart Doc' or as 'Product & Solution Documentation'? metadata is not complete yet (and a bit mixed currently)
- If 'Product & Solution Docs': which tasks to associate it with?
- If Smart Docs: which productname and productversions? 

