### PR TITLE
Container Guide: integrate proofing corrections

### DIFF
--- a/container-guide/concepts/containers-bci-intro.xml
+++ b/container-guide/concepts/containers-bci-intro.xml
@@ -58,7 +58,7 @@
       &bcia;s feature the same predictable enterprise lifecycle as &slsa;. The
       SLE_BCI 15 SP3 and SP4 repository (which is a subset of the &slea;
       repository) gives &bcia;s access to 4000 packages available for the
-      &x86-64;, &aarch64;, &power;, and &zseries; architectures. The packages in
+      &x86-64;, &aarch64;, &power; and &zseries; architectures. The packages in
       the repository have undergone quality assurance and security audits by
       &suse;. The container images are FIPS-compliant when running on a host in
       FIPS mode. In addition to that, &suse; can provide official support for

--- a/container-guide/concepts/containers-bci-understand.xml
+++ b/container-guide/concepts/containers-bci-understand.xml
@@ -106,7 +106,7 @@
       Enterprise repositories. This includes additional modules and previous
       package versions that are not part of the free SLE_BCI repository. Refer
       to <xref linkend="sec-container-suseconnect"/> for more information on
-      how to use the repository for &slsa;, &opensuse;, and non-&slsa; hosts.
+      how to use the repository for &slsa;, &opensuse; and non-&slsa; hosts.
     </para>
   </section>
   <section xml:id="sec-bci-tasks">

--- a/container-guide/concepts/containers-build-app-images.xml
+++ b/container-guide/concepts/containers-build-app-images.xml
@@ -78,7 +78,7 @@
     The following section provides examples and recommendations on creating
     container images for applications. Before proceeding, make sure that you
     have activated your &sls; base image as described in
-    <xref linkend="sec-download-prebuild-images"/> .
+    <xref linkend="sec-download-prebuild-images"/>.
   </para>
   <section xml:id="sec-application-with-specific-dependencies">
     <title>Running an application with specific package versions</title>
@@ -218,7 +218,7 @@
         After you specify a mount point by using the <literal>VOLUME</literal>
         instruction, all changes made to the directory with the
         <command>RUN</command> instruction are discarded. After the mount point
-        is specified, the volume becomes a part of a temporary container which
+        is specified, the volume becomes a part of a temporary container, which
         is removed after a successful build. This means that for certain
         actions to take effect, they must be performed
         <emphasis role="strong">before</emphasis> specifying a mount point. For
@@ -413,9 +413,9 @@
       </listitem>
       <listitem>
         <para>
-          Point a browser to
-          <link xlink:href="http://localhost:80/test.html">http://localhost:80/test.html</link>
-          . You should see the message <emphasis>The Web server is
+          Point a browser at
+          <link xlink:href="http://localhost:80/test.html">http://localhost:80/test.html</link>.
+          You should see the message <emphasis>The Web server is
           running</emphasis>.
         </para>
       </listitem>
@@ -478,14 +478,12 @@
     </orderedlist>
     <para>
       To view the published data, point a browser at
-      <link xlink:href="http://localhost:80/test.html">http://localhost:80/test.html</link>
-      .
+      <link xlink:href="http://localhost:80/test.html">http://localhost:80/test.html</link>.
     </para>
     <para>
       To avoid copying Web site data into the container, share a directory of
       the host with the container. For more information, see
-      <link xlink:href="https://docs.docker.com/storage/volumes/"/>
-      .
+      <link xlink:href="https://docs.docker.com/storage/volumes/"/>.
     </para>
   </section>
 </article>

--- a/container-guide/concepts/containers-build-images.xml
+++ b/container-guide/concepts/containers-build-images.xml
@@ -44,7 +44,7 @@
   <section xml:id="sec-customize-images">
     <title>Customizing container images</title>
     <section xml:id="sec-customize-repo-registration">
-      <title>Repositories and Registration</title>
+      <title>Repositories and registration</title>
       <para>
         The pre-built images do not have any repositories configured and do not
         include any modules or extensions. They contain a
@@ -116,9 +116,9 @@
       <para>
         This automatically adds all the repositories to the container. For each
         repository added to the system, a new file is created under
-        <filename>/etc/zypp/repos.d</filename> . The URLs of these repositories
+        <filename>/etc/zypp/repos.d</filename>. The URLs of these repositories
         include an access token that automatically expires after 12 hours. To
-        renew the token, run the command <command>zypper ref -s</command> .
+        renew the token, run the command <command>zypper ref -s</command>.
         Including these files in a container image does not pose any security
         risk.
       </para>
@@ -146,7 +146,7 @@
         For more information about <literal>podman build</literal> options, see
         the
         <link xlink:href="https://docs.podman.io/en/latest/markdown/podman-build.1.html">official
-        &podman; documentation</link> .
+        &podman; documentation</link>.
       </para>
     </section>
     <section xml:id="sec-docker-sle-images-customizing-the-images-sles12sp3">
@@ -177,7 +177,7 @@
       <title>Building container images in on-demand &slea; instances in the public cloud</title>
       <para>
         Building container images on &slea; instances that were launched as
-        on-demand or pay-as-you-go instances on a public cloud (AWS, GCE, or
+        on-demand or pay-as-you-go instances on a public cloud (AWS, GCE or
         Azure) requires additional steps. To install packages and updates, the
         on-demand public cloud instances are connected to the update
         infrastructure. This infrastructure is based on &rmt; servers operated

--- a/container-guide/concepts/containers-docker-registry.xml
+++ b/container-guide/concepts/containers-docker-registry.xml
@@ -42,7 +42,7 @@
     </listitem>
   </itemizedlist>
   <para>
-    Instead of using &dhub; you can run a local instance of &dreg;, an open
+    Instead of using &dhub;, you can run a local instance of &dreg;, an open
     source platform for storing and retrieving container images.
   </para>
   <section xml:id="sec-docker-registry-installation">

--- a/container-guide/concepts/containers-docker.xml
+++ b/container-guide/concepts/containers-docker.xml
@@ -198,7 +198,7 @@
       before applying a &deng; update.
     </para>
     <para>
-      To prevent data loss, avoid workloads that rely on containers which
+      To prevent data loss, avoid workloads that rely on containers that
       automatically start after &deng; update. Although it is technically
       possible to keep containers running during an update via the
       <option>--live-restore</option> option, such updates can introduce

--- a/container-guide/concepts/containers-intro.xml
+++ b/container-guide/concepts/containers-intro.xml
@@ -94,7 +94,7 @@
             <para>
               A container encapsulates binaries for a specific architecture
               (&x86-64; or &aarch64; for instance). So a container made for
-              &x86-64; only runs on a &x86-64; system host without the use of
+              &x86-64; only runs on an &x86-64; system host without the use of
               emulation.
             </para>
           </listitem>

--- a/container-guide/concepts/containers-orchestration.xml
+++ b/container-guide/concepts/containers-orchestration.xml
@@ -32,7 +32,7 @@
       <imageobject>
       <imagedata fileref="pods_architecture.png" width="80.0%"/>
       </imageobject>
-      <textobject><phrase>image</phrase></textobject>
+      <textobject><phrase>Image</phrase></textobject>
       </mediaobject>
       </informalfigure>
       <para>Each container in a pod has its own instance of a monitoring program. The monitoring program watches
@@ -52,7 +52,7 @@
     assign the desired name to a pod.</para>
     <screen>&prompt.user;podman pod create
     344940492c00b6a19ececbc5b109351bf0a3b8b19b3c279a097da7a653c592d0</screen>
-    <para>you can list our pods using the <command>podman pod list</command> command:</para>
+    <para>You can list our pods using the <command>podman pod list</command> command:</para>
     <screen>&prompt.user;podman pod list
     POD ID        NAME          STATUS      CREATED        INFRA ID      # OF CONTAINERS
     344940492c00  suspicious_curie  Created     2 minutes ago  617d7e3ce399  1</screen>
@@ -92,14 +92,14 @@
     &prompt.user;podman ps -a --pod
     CONTAINER ID  IMAGE                                COMMAND     CREATED         STATUS                       PORTS       NAMES               POD ID        PODNAME
     617d7e3ce399  localhost/podman-pause:4.3.1-1669118400                             25 minutes ago  Up 15 minutes ago                        344940492c00-infra  344940492c00  suspicious_curie 8f5af62a7c38  registry.suse.com/bci/bci-base:latest  sleep 1h    15 minutes ago  Exited (137) 14 seconds ago              objective_jemison   344940492c00  suspicious_curie</screen>
-    <para>You can also stop the pod and all of its containers using, podman pod stop</para>
+    <para>You can also stop the pod and all of its containers using <command>podman pod stop</command>:</para>
     <screen># podman pod stop suspicious_curie
     344940492c00b6a19ececbc5b109351bf0a3b8b19b3c279a097da7a653c592d0
     &prompt.user;podman ps -ap
     CONTAINER ID  IMAGE                                COMMAND     CREATED         STATUS                      PORTS       NAMES               POD ID        PODNAME
     617d7e3ce399  localhost/podman-pause:4.3.1-1669118400                             29 minutes ago  Exited (0) 7 seconds ago                344940492c00-infra  344940492c00  suspicious_curie 8f5af62a7c38  registry.suse.com/bci/bci-base:latest  sleep 1h    19 minutes ago  Exited (137) 3 minutes ago              objective_jemison   344940492c00  suspicious_curie</screen>
     <para>You can also start and restart everything with <command>sudo podman start <replaceable>CONTAINER_NAME</replaceable></command>,
-    <command>podman pod start <replaceable>POD_NAME</replaceable></command> or <command>podman pod restart <replaceable>POD_NAME</replaceable></command> .</para>
+    <command>podman pod start <replaceable>POD_NAME</replaceable></command> or <command>podman pod restart <replaceable>POD_NAME</replaceable></command>.</para>
     <para>There are two ways to remove pods. You can use the <command>podman pod rm</command> command to remove one or more pods.
     Alternatively, you can remove all stopped pods using the <command>podman pod prune</command> command.
     To remove a pod or several pods, run the <command>podman pod rm</command> command as follows:</para>
@@ -116,12 +116,12 @@
     exact purpose, they are intended to be used for highly distributed and scalable
     systems with hundreds of nodes, and not for a single machine. systemd and &podman;
     are much better suited for the single-machine scenario, as they do not add
-    another layer complexity to your existing setup.</para>
+    another layer of complexity to your existing setup.</para>
 
     <para>&podman; supports creating systemd unit files with
     the <command>podman generate systemd</command> subcommand. The subcommand creates a systemd unit
     file, making it possible to control a container or pod via systemd. Using the
-    unit file you can launch a container or pod on boot, automatically restart it if
+    unit file, you can launch a container or pod on boot, automatically restart it if
     a failure occurs, and keep its logs in journald.</para>
 
     <para>The following example uses a simple NGINX container:</para>
@@ -166,8 +166,8 @@
     into the system unit systemd directory (<filename>/etc/systemd/system</filename>) and control the
     container via systemd. The <option>--new</option> flag instructs &podman; to recreate the
     container on a restart. This ensures that the systemd unit is self-contained,
-    and it does not depend on external state. The <option>--name</option> flag allows you to assign
-    a user-friendly name to the container: without it &podman; uses container IDs
+    and it does not depend on any external state. The <option>--name</option> flag allows you to assign
+    a user-friendly name to the container: without it, &podman; uses container IDs
     instead of their names.</para>
     <para>To control the container as a user unit, proceed as follows:</para>
     <screen>&prompt.user;podman generate systemd --name --new --files web
@@ -178,7 +178,7 @@
     <screen>&prompt.user;systemctl --user start container-web
     &prompt.user;systemctl --user is-active container-web.service
     active</screen>
-    <para>Run the <command>podman ps</command> command to see the list of all running containers :</para>
+    <para>Run the <command>podman ps</command> command to see the list of all running containers:</para>
     <screen>&prompt.user;podman ps
     CONTAINER ID  IMAGE                           COMMAND               CREATED         STATUS             PORTS                 NAMES
     af92743971d2  docker.io/library/nginx:latest  nginx -g daemon o...  15 minutes ago  Up 15 minutes ago  0.0.0.0:8080-&gt;80/tcp  web</screen>
@@ -195,15 +195,15 @@
     CONTAINER ID  IMAGE                           COMMAND               CREATED        STATUS            PORTS                 NAMES
     0b5be4493251  docker.io/library/nginx:latest  nginx -g daemon o...  4 seconds ago  Up 4 seconds ago  0.0.0.0:8080-&gt;80/tcp  web</screen>
     <para>Note that the container is <emphasis role="strong">not</emphasis> restarted when it is stopped gracefully,
-    e.g. via <command>podman stop web</command>. To always restart it, add the flag
+    for example, via <command>podman stop web</command>. To always restart it, add the flag
     <option>--restart-policy=always</option> to <command>podman generate systemd</command>.</para>
     </section>
     <section xml:id="id-updating-container-images">
     <title>Updating container images</title>
     <para>Using the described approach means that the container image is never
-    updated. You can solve the problem by adding the <option>--pull=always</option> flag to the
+    updated. You can solve this problem by adding the <option>--pull=always</option> flag to the
     <option>ExecStart=</option> entry in the unit file. But be aware that this increases the
-    startup time of the container and updates the image on <emphasis role="strong">every</emphasis> restart. The
+    start-up time of the container and updates the image on <emphasis role="strong">every</emphasis> restart. The
     latter also means that a container image update can make the container
     unavailable outside of a scheduled maintenance window due to a newly
     introduced bug.</para>
@@ -213,11 +213,11 @@
     <option>io.containers.autoupdate=registry</option> to a container to make &podman; pull a new
     version of the container image from the registry when running <command>podman
     auto-update</command>. This makes it possible to update all container images with a
-    single command at a desired time, and without increasing the startup time of the
+    single command at a desired time, and without increasing the start-up time of the
     systemd units.</para>
-    <para>The auto update feature can be enabled by adding the line <option>--label
+    <para>The auto-update feature can be enabled by adding the line <option>--label
     "io.containers.autoupdate=registry" \</option> to the <option>ExecStart=</option> entry of the
-    container's systemd unit file. for the NGINX example, modify
+    container's systemd unit file. For the NGINX example, modify
     <literal>~/.config/systemd/user/container-web.service</literal> as follows:</para>
     <screen>ExecStart=/usr/bin/podman run \
             --cidfile=%t/%n.ctr-id \
@@ -235,7 +235,7 @@
     UNIT                   CONTAINER           IMAGE            POLICY      UPDATED
     container-web.service  87d263489307 (web)  docker.io/nginx  registry    false</screen>
     <para>It is good practice to have external testing in place to make sure that image
-    updates are generally safe to be deployed. If you are confident in the quality
+    updates are generally safe to be deployed. If you are confident of the quality
     of our container image, you can let &podman; automatically apply image updates
     periodically by enabling the <option>podman-auto-update.timer</option>:</para>
     <screen># only for the current user
@@ -277,7 +277,7 @@
     2948fa1476c6  localhost/podman-pause:4.2.0-1660228937                        2 minutes ago       Up About a minute ago  0.0.0.0:8080-&gt;80/tcp  736cab072c49-infra
     ffd2fbd6d445  docker.io/library/drupal:latest          apache2-foregroun...  About a minute ago  Up About a minute ago  0.0.0.0:8080-&gt;80/tcp  drupal-frontend
     a4dc31b24000  docker.io/library/postgres:11            postgres              40 seconds ago      Up 41 seconds ago      0.0.0.0:8080-&gt;80/tcp  drupal-pg</screen>
-    <para>Creating a systemd unit for the pod is done similar to a
+    <para>Creating a systemd unit for the pod is done similarly to a
     single container:</para>
     <screen language="Shell" linenumbering="unnumbered">&prompt.user;podman generate systemd --name --new --files drupal
     /home/user/pod-drupal.service
@@ -309,7 +309,7 @@
     <section xml:id="sec-orchestration-podman-more">
     <title>More on &podman;</title>
     <para>If you want to learn more about &podman; and handling pod deployment,
-    please check <link xlink:href="https://docs.podman.io/en/latest/">https://docs.podman.io/en/latest/</link> and <link xlink:href="https://github.com/containers/podman">https://github.com/containers/podman</link></para>
+    please check <link xlink:href="https://docs.podman.io/en/latest/">https://docs.podman.io/en/latest/</link> and <link xlink:href="https://github.com/containers/podman">https://github.com/containers/podman</link>.</para>
     </section>
     <section xml:id="sec-orchestration-kubernetes">
     <title>Multi-container host with &kube;</title>
@@ -319,15 +319,15 @@
     
     <para>&kube; makes it possible for multiple machines (or servers or nodes) to work together and create a cluster that you can
     then interact with through APIs. We recommend using <link xlink:href="https://ranchermanager.docs.rancher.com">Rancher</link> for deploying &kube; clusters and managing applications running on top of them. A single Rancher setup can manage multiple &kube; clusters running anywhere: from bare-metal, to on-prem or cloud service providers.</para>
-    <para>For more information on Ranger, refer to the <link xlink:href="https://ranchermanager.docs.rancher.com">official Rancher documentation</link>.</para>
+    <para>For more information on Rancher, refer to the <link xlink:href="https://ranchermanager.docs.rancher.com">official Rancher documentation</link>.</para>
     </section>
     <section xml:id="sec-k3s">
     <title>Lightweight &kube; (k3s)</title>
-    <para><link xlink:href="https://k3s.io">K3s</link> is lightweight CNCF-certified &kube; distribution
-    built for IoT &amp; Edge computing. Unlike &kube; K3s is packaged as a single &lt;60 MB binary and
+    <para><link xlink:href="https://k3s.io">K3s</link> is a lightweight CNCF-certified &kube; distribution
+    built for IoT and Edge computing. Unlike &kube;, K3s is packaged as a single &lt;60 MB binary and
     optimized for the &arm; architecture.</para>
     <para>For more info, refer to
     <link xlink:href="https://www.suse.com/c/rancher_blog/introduction-to-k3s/">Introduction to K3s</link> and
-    <link xlink:href="https://documentation.suse.com/trd/kubernetes/single-html/kubernetes_ri_rancher-k3s-sles/index.html#id-introduction">how to install K3s and Rancher on SUSE Linux Enterprise Server</link></para>
+    <link xlink:href="https://documentation.suse.com/trd/kubernetes/single-html/kubernetes_ri_rancher-k3s-sles/index.html#id-introduction">How to install K3s and Rancher on SUSE Linux Enterprise Server</link>.</para>
     </section>
 </article>

--- a/container-guide/concepts/containers-podman.xml
+++ b/container-guide/concepts/containers-podman.xml
@@ -136,7 +136,7 @@
       When using rootless containers with &podman;, it is recommended to use
       cgroups v2. cgroups v1 are limited in terms of functionality compared to
       v2. For example, cgroups v1 do not allow proper hierarchical delegation to
-      user's subtrees. Additionally, &podman; is unable to read container logs
+      the user's subtrees. Additionally, &podman; is unable to read container logs
       properly with cgroups v1 and the systemd log driver. To enable cgroups v2,
       add the following to the kernel cmdline:
       <option>systemd.unified_cgroup_hierarchy=1</option>
@@ -286,7 +286,7 @@
       </para>
       <para>
         &podman; also features a &deng; compatible socket that can be launched
-        use the following command:
+        using the following command:
       </para>
 <screen>&prompt.user;sudo systemctl start podman.socket</screen>
       <para>
@@ -345,8 +345,8 @@
   <section xml:id="sec-podman-tag">
     <title>Renaming images and images tag</title>
     <para>
-      Tags are used to assign container images descriptive names, thus making
-      it easier to identify individual images.
+      Tags are used to assign descriptive names to container images, 
+      thus making it easier to identify individual images.
     </para>
     <para>
       Pull the &bcia;-Base image from &suseregistry;:

--- a/container-guide/concepts/containers-repo-reg.xml
+++ b/container-guide/concepts/containers-repo-reg.xml
@@ -16,11 +16,11 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
   <info>
-    <title>Registration and Online Repositories</title>
+    <title>Registration and online repositories</title>
   </info>
   <para>
     As a pre-requisite to work with containers on a &sls;, you have to enable
-    the &slea; Containers Module. It consists of container-related packages,
+    the &slea; Containers Module. This consists of container-related packages,
     including container engine and core container tools like on-premise
     registry. For more information about &slea; Modules, refer to
     <link xlink:href="https://documentation.suse.com/sles/html/&slea;S-all/article-modules.html"/>.

--- a/container-guide/concepts/containers-support.xml
+++ b/container-guide/concepts/containers-support.xml
@@ -118,7 +118,7 @@
       </para>
     </important>
     <para>
-      &bcia;s support the following architectures: &x86-64;, &aarch64;, &power;,
+      &bcia;s support the following architectures: &x86-64;, &aarch64;, &power;
       and &zsystems;. Container architecture must match the architecture of the
       host. Mismatching container and host scenarios are not supported.
     </para>
@@ -342,7 +342,7 @@
           products.
         </para>
         <para>
-          For example, &slsa;S 15 SP4 container images follow the &slsa; 15 SP4
+          For example, &slsa; 15 SP4 container images follow the &slsa; 15 SP4
           lifecycle.
         </para>
       </listitem>
@@ -406,7 +406,7 @@
       from &suse; repositories are also supported. Additional components and
       applications in the containers are not covered by &suse; support. No
       subscription is required for building derived containers based on the
-      content of the &slea; &bcia;s or the SLE_BCI Repository. To build
+      content of the &bcia;s or the SLE_BCI Repository. To build
       containers that include packages from the full &slea; universe, you need
       a subscription that grants you access to the repositories containing
       these packages.

--- a/container-guide/concepts/containers-tools.xml
+++ b/container-guide/concepts/containers-tools.xml
@@ -19,7 +19,7 @@
     <title>Tools for building images and managing containers</title>
   </info>
   <para>
-    All described tools described below are part of the
+    All the tools described below are part of the
     <emphasis role="strong">&sles; Containers
     Module</emphasis>, except the
     <link xlink:href="https://openbuildservice.org">Open Build Service</link>.
@@ -152,8 +152,7 @@
     </para>
     <para>
       For more information about &bcia;s, refer to
-      <xref linkend="container-bci-general"/>
-      .
+      <xref linkend="container-bci-general"/>.
     </para>
   </section>
   <section xml:id="sec-tools-kiwi">


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Container Guide from proofing drop 3.
There is an image missing in the PDF build:

PDF page 56
File: concepts/containers-orchestration.xml

Source:
```
 <informalfigure>
      <mediaobject>
      <imageobject>
      <imagedata fileref="pods_architecture.png" width="80.0%"/>
      </imageobject>
      <textobject><phrase>Image</phrase></textobject>
      </mediaobject>
   </informalfigure>
```


