### PR TITLE
Update hardware information gathered by SUSEConnect

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -302,7 +302,7 @@
           <row>
             <entry>Architecture specifics</entry>
             <entry>map</entry>
-            <entry>Depends on the architecture. It includes parameters such as devicetree information, virtualization type on PowerPC or System Z, among others</entry>
+            <entry>Depends on the architecture. It includes parameters such as device-tree information or virtualization type on PowerPC or System Z.</entry>
           </row>
           <row>
             <entry>SAP</entry>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -290,6 +290,41 @@
             <entry>KVM or VMware etc.</entry>
           </row>
           <row>
+            <entry>Container runtime</entry>
+            <entry>string</entry>
+            <entry>Docker</entry>
+          </row>
+          <row>
+            <entry>uname</entry>
+            <entry>string</entry>
+            <entry>Linux lair 6.9.7-1-default #1 SMP PREEMPT_DYNAMIC Fri Jun 28 05:50:47 UTC 2024 (a5efffa) x86_64 x86_64 x86_64 GNU/Linux</entry>
+          </row>
+          <row>
+            <entry>Architecture specifics</entry>
+            <entry>map</entry>
+            <entry>Depends on the architecture. It includes parameters such as devicetree information, virtualization type on PowerPC or System Z, among others</entry>
+          </row>
+          <row>
+            <entry>SAP</entry>
+            <entry>list</entry>
+            <entry>
+             <para>
+              For each SAP installation: system_id (string) and instance_types (list of strings)
+             </para>
+<screen>
+"sap": [
+    {
+      "system_id": "DEV",
+      "instance_types": [
+        "ASCS",
+        "D"
+      ]
+    }
+]
+</screen>
+            </entry>
+          </row>
+          <row>
             <entry>Cloud Provider</entry>
             <entry>string</entry>
             <entry>Amazon, Google, or Azure</entry>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -309,7 +309,7 @@
             <entry>list</entry>
             <entry>
              <para>
-              For each SAP installation: system_id (string) and instance_types (list of strings)
+              <literal>system_id</literal> (string) and <literal>instance_types</literal> (list of strings) for each SAP installation.
              </para>
 <screen>
 "sap": [


### PR DESCRIPTION
As part of our last epic, we have introduced more parameters which are being gathered and sent to scc.suse.com. The public documentation should reflect these new parameters being sent.