### PR TITLE
Changes to the server update procedure

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2272,8 +2272,10 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
   <section xml:id="sec-trento-updating-trentoserver">
     <title>Updating &t.server;</title>
-    <para> The procedure to update the &t.server; depends on how it was installed.
-     If it was installed manually, then it must be updated manually using the latest versions
+    <para> The procedure to update the &t.server; depends on the deployment type: kubernetes, systemd or containerized.
+    The current content of this section is specific for kubernetes deployments.</para?
+   <para>
+     If &t.server; was installed manually, then it must be updated manually using the latest versions
      of the container images available in the SUSE public registry. If it was installed using
      Helm chart, it can be updated using the same Helm command as for the installation:</para>
    <screen>helm upgrade \
@@ -2301,6 +2303,10 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
    --set trento-web.adminUser.password=<replaceable>ADMIN_PASSWORD</replaceable> \
    --set rabbitmq.auth.erlangCookie=$(openssl rand -hex 16)
         </screen>
+        </listitem>
+       <listitem>
+        <para>When updating from a Trento version lower than 2.3.1 to version 2.3.1 or higher, a new API key is generated
+        and the configuration of all registered agents must be updated accordingly.</para>
         </listitem>
         <listitem>
           <para> If email alerting has been enabled, then the corresponding <parameter>trento-web.alerting</parameter> flags


### PR DESCRIPTION
- Clarification that the current content of the Trento Server update section is specific to Kubernetes deployments.
- Clarification on need to update agent configuration with new API key when updating from version lower than 2.3.1 to 2.3.1 or higher
