### PR TITLE
PCI DSS: add metadata

### DIFF
--- a/pcidss/xml/art_security_pcidss.xml
+++ b/pcidss/xml/art_security_pcidss.xml
@@ -12,6 +12,7 @@
 
 <article xml:id="article-security-pcidss"
          xmlns="http://docbook.org/ns/docbook"
+         xmlns:its="http://www.w3.org/2005/11/its"
          version="5.0"
          xml:lang="en"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -44,6 +45,25 @@
     the data and the computing environment safe.
    </para>
   </abstract>
+  <meta name="title" its:translate="yes">&sle_pcidss_guide;</meta>
+  <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+  <meta name="description" its:translate="yes">How to configure &productnameshort; to comply with the &pcidss;</meta>
+
+  <meta name="social-descr" its:translate="yes">Configure &productnameshort; to comply with &pcidssa;</meta>
+  <meta name="task" its:translate="yes">
+    <phrase>Auditing</phrase>
+    <phrase>Compliance</phrase>
+  </meta>
+  <revhistory xml:id="rh-article-security-pcidss">
+    <revision>
+      <date>2020-07-21</date>
+      <revdescription>
+        <para>
+          Initial release of this document.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
  </info>
 
 

--- a/pcidss/xml/art_security_pcidss.xml
+++ b/pcidss/xml/art_security_pcidss.xml
@@ -50,7 +50,7 @@
   <meta name="description" its:translate="yes">How to configure &productnameshort; to comply with the &pcidss;</meta>
 
   <meta name="social-descr" its:translate="yes">Configure &productnameshort; to comply with &pcidssa;</meta>
-  <meta name="task" its:translate="yes">
+  <meta name="task" its:translate="no">
     <phrase>Auditing</phrase>
     <phrase>Compliance</phrase>
   </meta>


### PR DESCRIPTION
### PR creator: Description

Add metadata from 'Product Docs Metadata per deliverable' spreadsheet. 
Added a revhistory based on commit log. 

### PR creator: Are there any relevant issues/feature requests?

Link to our [internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation).

