### PR TITLE
SCC articles: add metadata

### DIFF
--- a/scc-hypervisor-collector/xml/art-scc-hypervisor-collector.xml
+++ b/scc-hypervisor-collector/xml/art-scc-hypervisor-collector.xml
@@ -11,6 +11,7 @@
 ]>
 <article xml:id="article-scc-hypervisor-collector"
          xmlns="http://docbook.org/ns/docbook"
+         xmlns:its="http://www.w3.org/2005/11/its"
          version="5.0"
          xml:lang="en"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -36,6 +37,23 @@
         customers' &scc; (SCC) account.
       </para>
     </abstract>
+    <meta name="title" its:translate="yes">Hypervisor details in &scc;</meta>
+    <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+    <meta name="description" its:translate="yes">How to monitor &scc; subscriptions for hypervisors</meta>
+    <meta name="social-descr" its:translate="yes">Monitoring SCC subscriptions for hypervisors</meta>
+    <meta name="task" its:translate="no">
+      <phrase>Subscription Management</phrase>
+    </meta>
+    <revhistory xml:id="rh-article-scc-hypervisor-collector">
+      <revision>
+        <date>2023-03-06</date>
+        <revdescription>
+          <para>
+            Initial release of this document.
+          </para>
+        </revdescription>
+      </revision>
+    </revhistory>
   </info>
   <sect1 xml:id="scc-hypervisor-collector-whatis">
     <title>What is &scchvc;?</title>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -11,6 +11,7 @@
 ]>
 <article xml:id="article-suseconnect-visibility"
          xmlns="http://docbook.org/ns/docbook"
+         xmlns:its="http://www.w3.org/2005/11/its"
          version="5.0"
          xml:lang="en"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -37,6 +38,23 @@
         about active systems and their hardware environment.
       </para>
     </abstract>
+    <meta name="title" its:translate="yes">Enriched system visibility in the &scc;</meta>
+    <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+    <meta name="description" its:translate="yes">How to use SUSEConnect to monitor active systems</meta>
+    <meta name="social-descr" its:translate="yes">Monitor active systems with SUSEConnect</meta>
+    <meta name="task" its:translate="no">
+      <phrase>Subscription Management</phrase>
+    </meta>
+    <revhistory xml:id="rh-article-suseconnect-visibility">
+      <revision>
+        <date>2022-09-22</date>
+        <revdescription>
+          <para>
+            Initial release of this document.
+          </para>
+        </revdescription>
+      </revision>
+    </revhistory>
   </info>
   <sect1 xml:id="suseconnect-whatis">
     <title>What is &suseconnect;?</title>

--- a/system-uptime-tracking/xml/art_system-uptime-tracking.xml
+++ b/system-uptime-tracking/xml/art_system-uptime-tracking.xml
@@ -49,7 +49,7 @@
     </meta>
     <revhistory xml:id="rh-article-system-uptime-tracking">
       <revision>
-        <date>???</date>
+        <date>2024-07-06</date>
         <revdescription>
           <para>
             Initial release of this document.

--- a/system-uptime-tracking/xml/art_system-uptime-tracking.xml
+++ b/system-uptime-tracking/xml/art_system-uptime-tracking.xml
@@ -11,6 +11,7 @@
 ]>
 <article xml:id="article-system-uptime-tracking"
          xmlns="http://docbook.org/ns/docbook"
+         xmlns:its="http://www.w3.org/2005/11/its"
          version="5.0"
          xml:lang="en"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -39,6 +40,23 @@
         for analytics purposes.
       </para>
     </abstract>
+    <meta name="title" its:translate="yes">System Uptime Tracking</meta>
+    <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+    <meta name="description" its:translate="yes">How to monitor the uptime of a client system</meta>
+    <meta name="social-descr" its:translate="yes">Monitoring the uptime of a client system</meta>
+    <meta name="task" its:translate="no">
+      <phrase>Subscription Management</phrase>
+    </meta>
+    <revhistory xml:id="rh-article-system-uptime-tracking">
+      <revision>
+        <date>???</date>
+        <revdescription>
+          <para>
+            Initial release of this document.
+          </para>
+        </revdescription>
+      </revision>
+    </revhistory>
   </info>
   <sect1 xml:id="uptime-requirements">
     <title>Requirements</title>


### PR DESCRIPTION
### PR creator: Description

Add metadata from 'Product Docs Metadata per deliverable' spreadsheet. 
Added a stub revhistory based on docserv-config logs.

### PR creator: Are there any relevant issues/feature requests?

Link to our [internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation).
