### PR TITLE
Single row for SAPHanaSR.py

### DIFF
--- a/sap-ha-support/xml/art-sap-ha-support.xml
+++ b/sap-ha-support/xml/art-sap-ha-support.xml
@@ -687,15 +687,9 @@
      </thead>
      <tbody>
       <row>
-       <entry>SAPHanaSR.py scale-up</entry>
+       <entry>SAPHanaSR.py</entry>
        <entry><link xlink:href="&dsc;/sbp/sap-15/html/SLES4SAP-hana-sr-guide-costopt-15/index.html#cha.s4s.hana-hook">Mandatory</link></entry>
        <entry><link xlink:href="&dsc;/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#cha.s4s.hana-hook">Mandatory</link></entry>
-       <entry>-</entry>
-      </row>
-      <row>
-       <entry>SAPHanaSR.py scale-out</entry>
-       <entry>-</entry>
-       <entry>-</entry>
        <entry>Legacy (mandatory for all versions before &hana;&nbsp;2.0 SPS03)</entry>
       </row>
       <row>


### PR DESCRIPTION
### PR creator: Description

Previously, there were separate rows for "SAPHanaSR.py scale-up" and "SAPHanaSR.py scale-out". However, we already have different columns for Scale-up and Scale-out. So, I've moved the content into a single row: 

![image](https://github.com/user-attachments/assets/5b500895-13ff-4c38-8a6a-ec11915d4e45)

### PR creator: Are there any relevant issues/feature requests?

* bsc#1213315
* jsc#DOCTEAM-1046

