### PR TITLE
Correct compatibility matrix

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2697,7 +2697,7 @@ trento-server-rabbitmq-0</screen>
         <tbody>
           <row>
             <!-- HINT: If you add more rows, raise add +1 to the morerows attribute value -->
-            <entry morerows="7" align="center" valign="middle">
+            <entry morerows="6" align="center" valign="middle">
               <para>&t.agent;</para>
               <para>versions</para>
             </entry>
@@ -2773,19 +2773,7 @@ trento-server-rabbitmq-0</screen>
           </row>
                     <row>
             <!-- <entry/> -->
-            <entry>2.3.1</entry>
-            <entry></entry>
-            <entry></entry>
-            <entry></entry>
-            <entry><phrase role="color:suse-jungle-green">✓</phrase></entry>
-            <entry><phrase role="color:suse-jungle-green">✓</phrase></entry>
-            <entry><phrase role="color:suse-jungle-green">✓</phrase></entry>
-            <entry><phrase role="color:suse-jungle-green">✓</phrase></entry>
-            <entry></entry>
-          </row>
-                   <row>
-            <!-- <entry/> -->
-            <entry>2.3.2</entry>
+            <entry>2.3.0</entry>
             <entry></entry>
             <entry></entry>
             <entry></entry>


### PR DESCRIPTION
This PR should be merged and publish right away once reviewed and approved. 

Changes to compatibility matrix:
- removal of last row (trento agent 2.3.2)
- change agent version 2.3.1 with 2.3.0
- add check mark for agent version 2.3.0 and server version 2.3.3

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

