### PR TITLE
PCI-DSS Guide: fix localized metadata

### DIFF
--- a/pcidss/l10n/zh-cn/xml/art_security_pcidss.xml
+++ b/pcidss/l10n/zh-cn/xml/art_security_pcidss.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
  type="text/xml"
  title="Profiling step"?>
-<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="art_security_pcidss.xml" xml:id="article-security-pcidss" version="5.0" xml:lang="zh-cn">
+<article xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="art_security_pcidss.xml" xml:id="article-security-pcidss" version="5.0" xml:lang="zh-cn" xmlns:its="http://www.w3.org/2005/11/its">
 
  <title>支付卡行业数据安全标准 (PCI DSS) 指南</title>
  <titleabbrev>支付卡行业数据安全标准 (PCI DSS) 指南</titleabbrev>
@@ -21,6 +21,25 @@
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
+  <meta name="title" its:translate="yes">支付卡行业数据安全标准 (PCI DSS) 指南</meta>
+  <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+  <meta name="description" its:translate="yes">如何配置 SLES 以符合支付卡行业数据安全标准</meta>
+
+  <meta name="social-descr" its:translate="yes">配置 SLES 以符合 PCI-DSS</meta>
+  <meta name="task" its:translate="no">
+    <phrase>Auditing</phrase>
+    <phrase>Compliance</phrase>
+  </meta>
+  <revhistory xml:id="rh-article-security-pcidss">
+    <revision>
+      <date>2020-07-21</date>
+      <revdescription>
+        <para>
+          Initial release of this document.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
 
   <abstract>
    <para>


### PR DESCRIPTION
### PR creator: Description

Fix localized metadata for PCI DSS Guide:
- based on additions for English (https://github.com/SUSE/doc-unversioned/pull/160)
- based on the spreadsheet with localized metadata for all guides in zh-cn