### PR TITLE
New path for Trento Support Config plugin

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2503,7 +2503,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
         <procedure>
           <step>
             <para>Download the Trento support plugin script:</para>
-            <screen>&prompt.root;<command>wget</command> https://raw.githubusercontent.com/trento-project/helm-charts/main/scripts/trento-support.sh</screen>
+            <screen>&prompt.root;<command>wget</command> https://raw.githubusercontent.com/trento-project/support/refs/heads/main/trento-support.sh</screen>
 
             <note>
               <title>Package available in &sles4sap; 15 SP3 and higher</title>


### PR DESCRIPTION
The Trento Support Config plugin has been moved to a new repo and the download path has changed. This PR replaces the old path with the new one.

This PR can be merged as soon as it is reviewed and approved. No need to wait for next version.

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...

