### PR TITLE
New section for activity log

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -980,7 +980,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - User modifications
      - User deletions
      - Profile updates.</para>
-     <para>Entries in the Activity Log are sorted out from newer to older. By clicking Refresh the user can update the Activity Log view with entries generated since they accessed the view or clicked Refresh last.</para>
+     <para>Entries in the Activity Log are sorted from newer to older. By clicking Refresh, the user can update the Activity Log view with entries generated since they accessed the view, or after the last refresh.</para>
      <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
       page and back to first one.</para>
      <para>The default retention time for entries in the Activity Log is one month. But it can be changed in the Activity Log section under Settings. Changing the retention time requires all:settings permissions. Expired entries,

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -966,12 +966,12 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     <title>Activity Log</title>
     <para> Trento collects system events and user actions in the Activity Log, which can be accessed from the left hand side panel of the Trento console.</para>
     <para> Each entry in the Activity Log consists of:
-     - A timestamp: what day and time the system event or the user action happened
+     - A timestamp: what day and time (server time, not browser time) the system event or the user action happened                            
      - A message: what type of event or user action happened.
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
     <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
      <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action. Only active users are available for filtering.
-      It also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, please bear in mind the time difference with the database (server) time.   - 
+      It also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, please bear in mind the time difference with the server time.   - 
      </para>
      <para>Once a filter has been set, the user must click Apply to filter out the undesired entries and Reset to remove all the filters.</para>
      <para>Entries related to user management can only be displayed by users that have all:all or all:users permissions. Particularly:
@@ -984,7 +984,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
       page and back to first one.</para>
      <para>The default retention time for entries in the Activity Log is one month. But it can be changed in the Activity Log section under Settings. Changing the retention time requires all:settings permissions. Expired entries,
-      based on the stablished retention time, are deleted on a daily basis at midnight (database time).</para>
+      based on the stablished retention time, are deleted on a daily basis at midnight (server time).</para>
    </section>
   <section xml:id="sec-trento-checks">
     <title>Performing configuration checks</title>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -964,7 +964,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
   -->
    <section xml:id="sec-activity-log">
     <title>Activity Log</title>
-    <para> Trento collects system events and user actions in the activity log, which can be access from the left hand side panel in the Trento console.</para>
+    <para> Trento collects system events and user actions in the Activity Log, which can be accessed from the left hand side panel of the Trento console.</para>
     <para> Each entry in the Activity Log consists of:
      - A timestamp: what day and time the system event or the user action happened
      - A message: what type of event or user action happened.

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -966,7 +966,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     <title>Activity Log</title>
     <para> Trento collects system events and user actions in the Activity Log. It can be accessed from the left-hand side panel of the Trento console.</para>
     <para> Each entry in the Activity Log includes the following:
-     - A timestamp: what day and time (server time, not browser time) the system event or the user action happened                            
+     - A timestamp: the day and time (server time, not browser time) the system event or the user action occurred                            
      - A message: what type of event or user action happened.
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
     <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -980,11 +980,11 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - User modifications
      - User deletions
      - Profile updates.</para>
-     <para>Entries in the Activity Log are sorted out from newer to older. By clicking Refresh the user can update the Activity Log view with entries generated since he accssed the view or clicked Refresh last.</para>
+     <para>Entries in the Activity Log are sorted out from newer to older. By clicking Refresh the user can update the Activity Log view with entries generated since they accessed the view or clicked Refresh last.</para>
      <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
       page and back to first one.</para>
-     <para>The default retention time for entries in teh Activity Log is one month. But it can be changed in the Activity Log secction under Settings. Change the retention period requires all:settings permissions. Expired entries,
-      based on the stablished retention period, are deleted on a daily basis at midnight (database time).</para>
+     <para>The default retention time for entries in teh Activity Log is one month. But it can be changed in the Activity Log secction under Settings. Changing the retention time requires all:settings permissions. Expired entries,
+      based on the stablished retention time, are deleted on a daily basis at midnight (database time).</para>
    </section>
   <section xml:id="sec-trento-checks">
     <title>Performing configuration checks</title>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -974,7 +974,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
       The Activity Log also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, keep in mind the time difference with the server time.   - 
      </para>
      <para>Once a filter has been set, the user must click Apply to filter out the undesired entries and Reset to remove all the filters.</para>
-     <para>Entries related to user management can only be displayed by users that have all:all or all:users permissions. Particularly:
+     <para>Entries related to user management can only be displayed by users that have the all:all or all:users permissions. This includes:
      - Login attempts
      - User creations
      - User modifications

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -983,7 +983,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      <para>Entries in the Activity Log are sorted out from newer to older. By clicking Refresh the user can update the Activity Log view with entries generated since they accessed the view or clicked Refresh last.</para>
      <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
       page and back to first one.</para>
-     <para>The default retention time for entries in teh Activity Log is one month. But it can be changed in the Activity Log secction under Settings. Changing the retention time requires all:settings permissions. Expired entries,
+     <para>The default retention time for entries in the Activity Log is one month. But it can be changed in the Activity Log section under Settings. Changing the retention time requires all:settings permissions. Expired entries,
       based on the stablished retention time, are deleted on a daily basis at midnight (database time).</para>
    </section>
   <section xml:id="sec-trento-checks">

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -962,6 +962,30 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - what to do when database status is not green
      - what to do wen SAP instances status is not green
   -->
+   <section xml:id="sec-activity-log">
+    <title>Activity Log</title>
+    <para> Trento collects system events and user actions in the activity log, which can be access from the left hand side panel in the Trento console.</para>
+    <para> Each entry in the Activity Log consists of:
+     - A timestamp: what day and time the system event or the user action happened
+     - A message: what type of event or user action happened.
+     - The user that triggered the event or performed the action.</para>
+    <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
+     <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action.
+      It also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, please bear in mind the time difference with the database (server) time.   - 
+     </para>
+     <para>Once a filter has been set, the user must click Apply to effectively apply the filter in the view and Reset to undo it it.</para>
+     <para>Entries related to user management can only be displayed by users that have all:all or all:users permissions. Particularly:
+     - Login attempts
+     - User creations
+     - User modifications
+     - User deletions
+     - Profile updates.</para>
+     <para>Entries in the Activity Log are sorted out from newer to older. By clicking Refresh the user can update the Activity Log view with entries generated since he accssed the view or clicked Refresh last.</para>
+     <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
+      page and back to first one.</para>
+     <para>The default retention time for entries in teh Activity Log is one month. But it can be changed in the Activity Log secction under Settings. Change the retention period requires all:settings permissions. Expired entries,
+      based on the stablished retention period, are deleted on a daily basis at midnight (database time).</para>
+   </section>
   <section xml:id="sec-trento-checks">
     <title>Performing configuration checks</title>
     <remark>toms 2024-04-18 (change#8): First saptune related configuration checks (host and cluster specific) -> update</remark>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -967,7 +967,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     <para> Trento collects system events and user actions in the Activity Log. It can be accessed from the left-hand side panel of the Trento console.</para>
     <para> Each entry in the Activity Log includes the following:
      - A timestamp: the day and time (server time, not browser time) the system event or the user action occurred                            
-     - A message: what type of event or user action happened.
+     - A message: type of the occurred event or user action.
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
     <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
      <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action. Only active users are available for filtering.

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -983,8 +983,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      <para>Entries in the Activity Log are sorted from newer to older. By clicking Refresh, the user can update the Activity Log view with entries generated since they accessed the view, or after the last refresh.</para>
      <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
       page and back to first one.</para>
-     <para>The default retention time for entries in the Activity Log is one month. But it can be changed in the Activity Log section under Settings. Changing the retention time requires all:settings permissions. Expired entries,
-      based on the stablished retention time, are deleted on a daily basis at midnight (server time).</para>
+     <para>The default retention time for entries in the Activity Log is one month. This can be changed in the Activity Log section under Settings. Changing the retention time requires the all:settings permissions. Entries expired after the specified retention time are deleted every day at midnight (server time).</para>
    </section>
   <section xml:id="sec-trento-checks">
     <title>Performing configuration checks</title>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -968,12 +968,12 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
     <para> Each entry in the Activity Log consists of:
      - A timestamp: what day and time the system event or the user action happened
      - A message: what type of event or user action happened.
-     - The user that triggered the event or performed the action.</para>
+     - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
     <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
-     <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action.
+     <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action. Only active users are available for filtering.
       It also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, please bear in mind the time difference with the database (server) time.   - 
      </para>
-     <para>Once a filter has been set, the user must click Apply to effectively apply the filter in the view and Reset to undo it it.</para>
+     <para>Once a filter has been set, the user must click Apply to filter out the undesired entries and Reset to remove all the filters.</para>
      <para>Entries related to user management can only be displayed by users that have all:all or all:users permissions. Particularly:
      - Login attempts
      - User creations

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -964,7 +964,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
   -->
    <section xml:id="sec-activity-log">
     <title>Activity Log</title>
-    <para> Trento collects system events and user actions in the Activity Log, which can be accessed from the left hand side panel of the Trento console.</para>
+    <para> Trento collects system events and user actions in the Activity Log. It can be accessed from the left-hand side panel of the Trento console.</para>
     <para> Each entry in the Activity Log consists of:
      - A timestamp: what day and time (server time, not browser time) the system event or the user action happened                            
      - A message: what type of event or user action happened.

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -981,7 +981,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - User deletions
      - Profile updates.</para>
      <para>Entries in the Activity Log are sorted from newer to older. By clicking Refresh, the user can update the Activity Log view with entries generated since they accessed the view, or after the last refresh.</para>
-     <para>The pagination features at the bottom of the Activity Log allow the user to determine how many entries they want to see in a page, scroll back and forth through the different pages of the view or jump straight to the last 
+     <para>The pagination features at the bottom of the Activity Log allow the user to specify the number of entries to display in a page, scroll back and forth through the different pages of the view, and jump directly to the last 
       page and back to first one.</para>
      <para>The default retention time for entries in the Activity Log is one month. This can be changed in the Activity Log section under Settings. Changing the retention time requires the all:settings permissions. Entries expired after the specified retention time are deleted every day at midnight (server time).</para>
    </section>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -971,7 +971,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
     <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
      <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action. Only active users are available for filtering.
-      It also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, please bear in mind the time difference with the server time.   - 
+      The Activity Log also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, keep in mind the time difference with the server time.   - 
      </para>
      <para>Once a filter has been set, the user must click Apply to filter out the undesired entries and Reset to remove all the filters.</para>
      <para>Entries related to user management can only be displayed by users that have all:all or all:users permissions. Particularly:

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -965,7 +965,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
    <section xml:id="sec-activity-log">
     <title>Activity Log</title>
     <para> Trento collects system events and user actions in the Activity Log. It can be accessed from the left-hand side panel of the Trento console.</para>
-    <para> Each entry in the Activity Log consists of:
+    <para> Each entry in the Activity Log includes the following:
      - A timestamp: what day and time (server time, not browser time) the system event or the user action happened                            
      - A message: what type of event or user action happened.
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -969,7 +969,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
      - A timestamp: the day and time (server time, not browser time) the system event or the user action occurred                            
      - A message: type of the occurred event or user action.
      - The user that triggered the event or performed the action. User system is used for events triggered by the system itself.</para>
-    <para>A right chevron icon in the activity log entry, opens a modal with the activity metadata.</para>
+    <para>The right chevron icon in the activity log entry opens a modal with the activity metadata.</para>
      <para>The Activity Log allows to filter by the type of event or user action, commonly refered to as resource type, and by the user that triggered the event or performed the action. Only active users are available for filtering.
       The Activity Log also allows to filter out entries that are newer and/or older than an specific date and time. When setting time based entries, keep in mind the time difference with the server time.   - 
      </para>


### PR DESCRIPTION
This PR isto be reviewed ahead of the release of version 2.4. But it is not to be merged/published until the new version is out.

It delivers a new section for the Activity Log that will be available with the new version.

The new section should be located after the also new SSO integration section and before the section about performing configuration checks.