### PR TITLE
Improved explanation of facts-service-url parameter

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -750,7 +750,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
           <listitem>
             <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
             for communication with the checks engine (wanda). The right value of this parameter depends on
-            how Trento Server was deployed
+            how Trento Server was deployed.</para>
             <para> In a Kubernetes deployment, it should be amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/
              unless we have used helm to update the default RabbitMQ username and password (trento),
              in which case we should use the custom value. </para>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -753,7 +753,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             how &t.server; was deployed.</para>
             <para> In a Kubernetes deployment, it is <uri>amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/</uri>. If the default RabbitMQ username and password (trento) were updated using helm, 
             the parameter must use the custom value. </para>
-            <para> In a systemd or containerized deployment, the correct value is amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost. If trento_use and trento_user_password were replaced with custom values, you can use them.
+            <para> In a systemd or containerized deployment, the correct value is <uri>amqp://TRENTO_USER:TRENTO_USER_PASSWORD@TRENTO_SERVER_HOSTNAME:5672/vhost</uri>. If <replaceable>TRENTO_USER</replaceable> and <replaceable>TRENTO_USER_PASSWORD</replaceable> were replaced with custom values, you can use them.
             </para>
           </listitem>
           <listitem>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -751,11 +751,9 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
             for communication with the checks engine (wanda). The correct value of this parameter depends on
             how Trento Server was deployed.</para>
-            <para> In a Kubernetes deployment, it should be amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/
-             unless we have used helm to update the default RabbitMQ username and password (trento),
-             in which case we should use the custom value. </para>
-            <para> In a systemd or containerized deployment, it should be amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost
-             unless we have replaced trento_use and trento_user_password with custom values, in which case we should use them.
+            <para> In a Kubernetes deployment, it is amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/. If the default RabbitMQ username and password (trento) were updated using helm, 
+            the parameter must use the custom value. </para>
+            <para> In a systemd or containerized deployment, the correct value is amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost. If trento_use and trento_user_password were replaced with custom values, you can use them.
             </para>
           </listitem>
           <listitem>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -750,7 +750,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
           <listitem>
             <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
             for communication with the checks engine (wanda). The correct value of this parameter depends on
-            how Trento Server was deployed.</para>
+            how &t.server; was deployed.</para>
             <para> In a Kubernetes deployment, it is amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/. If the default RabbitMQ username and password (trento) were updated using helm, 
             the parameter must use the custom value. </para>
             <para> In a systemd or containerized deployment, the correct value is amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost. If trento_use and trento_user_password were replaced with custom values, you can use them.

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -751,7 +751,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
             <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
             for communication with the checks engine (wanda). The correct value of this parameter depends on
             how &t.server; was deployed.</para>
-            <para> In a Kubernetes deployment, it is amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/. If the default RabbitMQ username and password (trento) were updated using helm, 
+            <para> In a Kubernetes deployment, it is <uri>amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/</uri>. If the default RabbitMQ username and password (trento) were updated using helm, 
             the parameter must use the custom value. </para>
             <para> In a systemd or containerized deployment, the correct value is amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost. If trento_use and trento_user_password were replaced with custom values, you can use them.
             </para>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -748,8 +748,15 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         </para>
         <itemizedlist>
           <listitem>
-            <para><parameter>facts-service-url</parameter>: the address of the AMQP service shared with the checks engine, where fact gathering requests are received.
-           The right syntax is <uri>amqp://rabbitmq_user:rabbitmq_user_password@<replaceable>TRENTO_SERVER_HOSTNAME</replaceable>:5672/vhost</uri>. In a &k8s; deployment, the default rabbitmq_user is trento and the default rabbitmq_user_password is trento as well. In a systemd or containerized deployment, the rabbitmq_user and the rabbitmq_user_password are set by the user during the deployment process. The corresponding installation sections above set rabbitmq_user as trento_user and rabbitmq_user_password as trento_user_password. But obviously these are just examples and should be adjusted by the customer.</para>
+            <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
+            for communication with the checks engine (wanda). The right value of this parameter depends on
+            how Trento Server was deployed
+            <para> In a Kubernetes deployment, it should be amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/
+             unless we have used helm to update the default RabbitMQ username and password (trento),
+             in which case we should use the custom value. </para>
+            <para> In a systemd or containerized deployment, it should be amqp://trento_user:trento_user_password@TRENTO_SERVER_HOSTNAME:5672/vhost
+             unless we have replaced trento_use and trento_user_password with custom values, in which case we should use them.
+            </para>
           </listitem>
           <listitem>
             <para><parameter>server-url</parameter>: URL for the Trento Server (<uri>http://TRENTO_SERVER_HOSTNAME</uri>)

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -749,7 +749,7 @@ As agreed on https://confluence.suse.com/x/DAEcN on our Trento doc kick off
         <itemizedlist>
           <listitem>
             <para><parameter>facts-service-url</parameter>: the address of the AMQP RabbitMQ service used
-            for communication with the checks engine (wanda). The right value of this parameter depends on
+            for communication with the checks engine (wanda). The correct value of this parameter depends on
             how Trento Server was deployed.</para>
             <para> In a Kubernetes deployment, it should be amqp://trento:trento@TRENTO_SERVER_HOSTNAME:5672/
              unless we have used helm to update the default RabbitMQ username and password (trento),


### PR DESCRIPTION
An Improved explanation of the right value of the facts-service-url parameter in the agent configuration file.

Once reviewed, this PR should be merged and published (no need to wait for new version release).
