### PR TITLE
Update Trento Container Installation Instructions

### DIFF
--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -72,7 +72,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
      registry.suse.com/trento/trento-checks:latest
    ```
 
-1. Install trento-wanda on Docker:
+1. Deploy trento-wanda:
 
    ```bash
    docker run -d --name wanda \
@@ -91,7 +91,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
        -c "/app/bin/wanda eval 'Wanda.Release.init()' && /app/bin/wanda start"
    ```
 
-1. Install trento-web on Docker
+1. Deploy trento-web.
 
    Make sure to change the `ADMIN_USER` and `ADMIN_PASSWORD`. These credentials are required to login to the trento-web UI.
    Depending on how you intend to connect to the console, a working hostname, FQDN, or an IP is required in `TRENTO_WEB_ORIGIN` for HTTPS otherwise, websockets will fail to connect, causing no real-time updates on the UI.

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -14,7 +14,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    SUSEConnect --product sle-module-containers/15.5/x86_64
    ```
 
-   > **Note:** Using a different Service Pack than SP5 requires to change repository: [SLE15 SP3: `SUSEConnect --product sle-module-containers/15.3/x86_64`,SLE15 SP4: ` SUSEConnect --product sle-module-containers/15.4/x86_64`]
+   > **Note:** Using a different Service Pack than SP5 requires to change repository: [SLE15 SP3: `SUSEConnect --product sle-module-containers/15.3/x86_64`,SLE15 SP4: `SUSEConnect --product sle-module-containers/15.4/x86_64`]
 
 1. Install Docker:
 
@@ -36,9 +36,9 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    docker network create trento-net
    ```
 
-   > **Note:** When creating the trento-net network, Docker typically assigns a default subnet: `172.17.0.0/16`. Ensure that this subnet matches the one specified in your PostgreSQL configuration file (refer to`/var/lib/pgsql/data/pg_hba.conf`). If the subnet of `trento-net` differs from `172.17.0.0/16` then adjust `pg_hba.conf` and restart PostgreSQL.
+   > **Note:** When creating the `trento-net` network, Docker typically assigns a default subnet: `172.17.0.0/16`. Ensure that this subnet is allowed by the rules specified in your PostgreSQL configuration file. For more information, please refer to upstream's [`pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) documentation.
 
-1. Verify the subnet of trento-net:
+1. Verify the subnet of `trento-net`:
 
    ```bash
    docker network inspect trento-net --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -36,7 +36,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    docker network create trento-net
    ```
 
-   > **Note:** When creating the `trento-net` network, Docker typically assigns a default subnet: `172.17.0.0/16`. Ensure that this subnet is allowed by the rules specified in your PostgreSQL configuration file. For more information, please refer to upstream's [`pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) documentation.
+   > **Note:** When creating the `trento-net` network, Docker normally assigns a default subnet: `172.17.0.0/16`. Ensure that this subnet is allowed by the rules specified in your PostgreSQL configuration file. For more information, please refer to upstream's [`pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) documentation.
 
 1. Verify the subnet of `trento-net`:
 

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -63,7 +63,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
    ```
 
-1. Install the checks on the system in a shared volume
+1. Install the checks on the system in a shared volume:
 
    ```bash
    docker volume create trento-checks \

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -41,7 +41,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
 1. Verify the subnet of trento-net:
 
    ```bash
-   docker network inspect trento-net  --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+   docker network inspect trento-net --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
    ```
 
    Expected output:

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -69,7 +69,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    docker volume create trento-checks \
      && docker run \
      -v trento-checks:/usr/share/trento/checks \
-     registry.suse.com/trento/trento-checks:1.0.0
+     registry.suse.com/trento/trento-checks:latest
    ```
 
 1. Install trento-wanda on Docker:
@@ -87,7 +87,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
        -e DATABASE_URL=ecto://wanda_user:wanda_password@host.docker.internal/wanda \
        --restart always \
        --entrypoint /bin/sh \
-       registry.suse.com/trento/trento-wanda:1.2.0 \
+       registry.suse.com/trento/trento-wanda:latest \
        -c "/app/bin/wanda eval 'Wanda.Release.init()' && /app/bin/wanda start"
    ```
 
@@ -118,7 +118,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    -e TRENTO_WEB_ORIGIN='trento.example.com' \
    --restart always \
    --entrypoint /bin/sh \
-   registry.suse.com/trento/trento-web:2.2.0 \
+   registry.suse.com/trento/trento-web:latest \
    -c "/app/bin/trento eval 'Trento.Release.init()' && /app/bin/trento start"
    ```
 

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -157,4 +157,4 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    e859c07888ca   registry.suse.com/trento/trento-wanda:1.2.0   "/bin/sh -c '/app/bi…"   18 seconds ago   Up 16 seconds   0.0.0.0:4001->4000/tcp, :::4001->4000/tcp   wanda
    ```
 
-   Both containers should be running and listening on the specified ports.
+   Both containers must run and listen on the specified ports.

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -8,7 +8,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
 
 ### Install Docker container runtime
 
-1. Enable the container`s module:
+1. Enable the containers module:
 
    ```bash
    SUSEConnect --product sle-module-containers/15.5/x86_64

--- a/trento/migration/container-install.md
+++ b/trento/migration/container-install.md
@@ -63,6 +63,15 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
    REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
    ```
 
+1. Install the checks on the system in a shared volume
+
+   ```bash
+   docker volume create trento-checks \
+     && docker run \
+     -v trento-checks:/usr/share/trento/checks \
+     registry.suse.com/trento/trento-checks:1.0.0
+   ```
+
 1. Install trento-wanda on Docker:
 
    ```bash
@@ -70,6 +79,7 @@ Follow the steps in [4.2 systemd deployment](https://documentation.suse.com/sles
        -p 4001:4000 \
        --network trento-net \
        --add-host "host.docker.internal:host-gateway" \
+       -v trento-checks:/usr/share/trento/checks:ro \
        -e CORS_ORIGIN=localhost \
        -e SECRET_KEY_BASE=$WANDA_SECRET_KEY_BASE \
        -e ACCESS_TOKEN_ENC_SECRET=$ACCESS_TOKEN_ENC_SECRET \

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -60,7 +60,7 @@ docker network create trento-net
 </programlisting>
           <note>
             <para>
-             When creating the <literal>trento-net</literal> network, Docker assigns a default subnet:
+             When creating the <literal>trento-net</literal> network, Docker assigns a default subnet to it:
               <literal>172.17.0.0/16</literal>. Ensure that this subnet is allowed by the rules specified
               in your PostgreSQL configuration. For more information, please refer to upstream's
               <link xlink:href="https://www.postgresql.org/docs/current/auth-pg-hba-conf.html"><literal>pg_hba.conf</literal></link> documentation.

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -74,7 +74,7 @@ docker network create trento-net
             Verify the subnet of trento-net:
           </para>
 <programlisting language="bash">
-docker network inspect trento-net  --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
+docker network inspect trento-net --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
 </programlisting>
           <para>
             Expected output is as follows:

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -113,7 +113,7 @@ REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
           </para>
 <programlisting language="bash">
 docker volume create trento-checks \
-  && docker run \
+  &amp;&amp; docker run \
   -v trento-checks:/usr/share/trento/checks \
   registry.suse.com/trento/trento-checks:1.0.0
 </programlisting>

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -60,18 +60,16 @@ docker network create trento-net
 </programlisting>
           <note>
             <para>
-              When creating the trento-net network, Docker assigns a default subnet:
-              <literal>172.17.0.0/16</literal>. Ensure that this subnet matches the one specified
-              in your PostgreSQL configuration file (refer
-              to<filename>/var/lib/pgsql/data/pg_hba.conf</filename>). If the subnet of
-              <literal>trento-net</literal> differs from <literal>172.17.0.0/16</literal> then
-              adjust <literal>pg_hba.conf</literal> and restart PostgreSQL.
+             When creating the <literal>trento-net</literal> network, Docker assigns a default subnet:
+              <literal>172.17.0.0/16</literal>. Ensure that this subnet is allowed by the rules specified
+              in your PostgreSQL configuration. For more information, please refer to upstream's
+              <link xlink:href="https://www.postgresql.org/docs/current/auth-pg-hba-conf.html"><literal>pg_hba.conf</literal></link> documentation.
             </para>
           </note>
         </step>
         <step>
           <para>
-            Verify the subnet of trento-net:
+            Verify the subnet of <literal>trento-net</literal>:
           </para>
 <programlisting language="bash">
 docker network inspect trento-net --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -220,7 +220,7 @@ CONTAINER ID   IMAGE                                         COMMAND            
 e859c07888ca   registry.suse.com/trento/trento-wanda:1.2.0   &quot;/bin/sh -c '/app/bi…&quot;   18 seconds ago   Up 16 seconds   0.0.0.0:4001-&gt;4000/tcp, :::4001-&gt;4000/tcp   wanda
 </programlisting>
           <para>
-            Both containers should be running and listening on the specified ports.
+            Both containers must run and listen on the specified ports.
           </para>
         </step>
       </procedure>

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -16,7 +16,7 @@
       <procedure>
         <step>
           <para>
-            Enable the Container module:
+            Enable the containers module:
           </para>
 <programlisting language="bash">
 SUSEConnect --product sle-module-containers/15.5/x86_64

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -95,7 +95,7 @@ docker network inspect trento-net --format '{{range .IPAM.Config}}{{.Subnet}}{{e
               Consider using an environment variable file (see
               <link xlink:href="https://docs.docker.com/engine/reference/commandline/run/#env">official
               Docker documentation</link>). Adjust the docker command below for use with the env file. In any case, make sure you keep a copy of the generated keys in a safe location, in case you need to
-             reuse them in the future. 
+             reuse them in the future.
             </para>
           </note>
 <programlisting language="bash">

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -109,6 +109,17 @@ REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
         </step>
         <step>
           <para>
+            Install the checks on the system in a shared volume
+          </para>
+<programlisting language="bash">
+docker volume create trento-checks \
+  && docker run \
+  -v trento-checks:/usr/share/trento/checks \
+  registry.suse.com/trento/trento-checks:1.0.0
+</programlisting>
+        </step>
+        <step>
+          <para>
             Deploy trento-wanda:
           </para>
 <programlisting language="bash">
@@ -116,6 +127,7 @@ docker run -d --name wanda \
     -p 4001:4000 \
     --network trento-net \
     --add-host &quot;host.docker.internal:host-gateway&quot; \
+    -v trento-checks:/usr/share/trento/checks:ro \
     -e CORS_ORIGIN=localhost \
     -e SECRET_KEY_BASE=$WANDA_SECRET_KEY_BASE \
     -e ACCESS_TOKEN_ENC_SECRET=$ACCESS_TOKEN_ENC_SECRET \

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -62,7 +62,7 @@ docker network create trento-net
             <para>
              When creating the <literal>trento-net</literal> network, Docker assigns a default subnet to it:
               <literal>172.17.0.0/16</literal>. Ensure that this subnet is allowed by the rules specified
-              in your PostgreSQL configuration. For more information, please refer to upstream's
+              in your PostgreSQL configuration. For more information, refer to the upstream
               <link xlink:href="https://www.postgresql.org/docs/current/auth-pg-hba-conf.html"><literal>pg_hba.conf</literal></link> documentation.
             </para>
           </note>

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -107,7 +107,7 @@ REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
         </step>
         <step>
           <para>
-            Install the checks on the system in a shared volume
+            Install the checks on the system in a shared volume:
           </para>
 <programlisting language="bash">
 docker volume create trento-checks \

--- a/trento/xml/container-install.xml
+++ b/trento/xml/container-install.xml
@@ -113,7 +113,7 @@ REFRESH_TOKEN_ENC_SECRET=$(openssl rand -out /dev/stdout 48 | base64)
 docker volume create trento-checks \
   &amp;&amp; docker run \
   -v trento-checks:/usr/share/trento/checks \
-  registry.suse.com/trento/trento-checks:1.0.0
+  registry.suse.com/trento/trento-checks:latest
 </programlisting>
         </step>
         <step>
@@ -133,7 +133,7 @@ docker run -d --name wanda \
     -e DATABASE_URL=ecto://wanda_user:wanda_password@host.docker.internal/wanda \
     --restart always \
     --entrypoint /bin/sh \
-    registry.suse.com/trento/trento-wanda:1.2.0 \
+    registry.suse.com/trento/trento-wanda:latest \
     -c &quot;/app/bin/wanda eval 'Wanda.Release.init()' &amp;&amp; /app/bin/wanda start&quot;
 </programlisting>
         </step>
@@ -174,7 +174,7 @@ docker run -d \
 -e TRENTO_WEB_ORIGIN='trento.example.com' \
 --restart always \
 --entrypoint /bin/sh \
-registry.suse.com/trento/trento-web:2.2.0 \
+registry.suse.com/trento/trento-web:latest \
 -c &quot;/app/bin/trento eval 'Trento.Release.init()' &amp;&amp; /app/bin/trento start&quot;
 </programlisting>
           <para>


### PR DESCRIPTION
This is part of the new version if the Trento release and therefore should go
together with the other PRs by @abravosuse.  I didn't see his existing PRs
before opening this one.  Sorry for the confusion this might have introduced

----

### PR creator: Description

As part of the recent updates to [Trento](https://github.com/trento-project),
we separated the Trento checks into it's own
[package & repo](https://github.com/trento-project/checks)

The separation requires updates to the container installation.  This allows the
user to update the checks separately from Wanda.  An update to the systemd
/ RPM instructions is not required, because Wanda pulls the newly created
RPM as part of its dependencies 

I will make at least two more PRs in the following days, because I plan to remove
all references of Trento Premium from the xml file, since we finally eliminated the
open-core model 🥳 .  Furthermore, I might need to update the Kubernetes
instructions.  If you want I can do these together in one PR or split them, so the
workload of reviewing is more manageable :D

### PR creator: Are there any relevant issues/feature requests?

I don't think so

