### PR TITLE
Update to the Trento Server Uninstalling Section

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2397,7 +2397,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
    <section xml:id="sec-trento-uninstall-trentoserver">
     <title>Uninstalling &t.server;</title>
-    <para>The procedure to update the Trento Server depends on the deployment type: Kubernetes, systemd or containerized. The current content of this section is specific for Kubernetes deployments.</para>
+    <para>The procedure to update the Trento Server depends on the deployment type: Kubernetes, systemd or containerized. The section covers Kubernetes deployments.</para>
     <para> If &t.server; was deployed manually, then you need to uninstall it manually.
      If  &t.server; was deployed using the Helm chart, you can also use Helm to uninstall it as follows:</para>
      <screen>helm uninstall trento-server</screen>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2397,6 +2397,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
    <section xml:id="sec-trento-uninstall-trentoserver">
     <title>Uninstalling &t.server;</title>
+    <para>The procedure to update the Trento Server depends on the deployment type: Kubernetes, systemd or containerized. The current content of this section is specific for Kubernetes deployments.</para>
     <para> If &t.server; was deployed manually, then you need to uninstall it manually.
      If  &t.server; was deployed using the Helm chart, you can also use Helm to uninstall it as follows:</para>
      <screen>helm uninstall trento-server</screen>


### PR DESCRIPTION
This PR can be merged/published once reviewed, no need to wait for the new version of Trento to be out.

The current content of the Uninstalling Trento Server section is specific to Kubernetes deployment. We are just adding a note saying so.
