### PR TITLE
Updates to the Reporting a Problem and Problem Analysis Sections

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2479,7 +2479,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
     <section>
       <title>&t.server;</title>
-      <para>To analyze issues &t.server; in a &K8s; scenario, we have two tools at our
+      <para>To analyze issues with &t.server; in a &K8s; scenario, we have two tools at our
         disposal. They both help us collect information/data that might be
         useful when troubleshooting/analyzing the issue.</para>
 

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2479,8 +2479,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
     <section>
       <title>&t.server;</title>
-      <para>To analyze issues with &t.server; in a &K8s; scenario, we have two tools at our
-        disposal. They both help us collect information/data that might be
+      <para>There are two tools you can use to analyze issues with &t.server; in a &K8s; scenario. They both help us collect information/data that might be
         useful when troubleshooting/analyzing the issue.</para>
 
       <section>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2445,12 +2445,12 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
     </para>
       <para>
       When opening a support case for Trento, provide the chosen deployment option for &t.server;: &K8s;, systemd or containerized.</para>
-   <para>In the case of a &K8s; deployment, provide also the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
+   <para>In case of a &K8s; deployment, provide the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
     </para>
-   <para>In the case of a systemd deployment, provide the status and the journal of the trento-web and trento-wanda services.
+   <para>In case of a systemd deployment, provide the status and the journal of the trento-web and trento-wanda services.
     </para>
-   <para>Finally, in the case of a containerized deployment, provide the logs of the trento-web and trento-wanda containers. Use docker ps to retrieve
-    the IDs of both containers, then docker logs <container_id> to retrieve the corresponding logs.
+   <para>In case of a containerized deployment, provide the logs of the trento-web and trento-wanda containers. Use <command>docker ps</command> to retrieve
+    the IDs of both containers, then <command>docker logs <replaceable>CONTAINER_ID</replaceable> to retrieve the corresponding logs.
     </para>
    <para>
       For issues with a particular &t.agent;, or a component discovered by a particular &t.agent;, also provide the following:

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2472,14 +2472,14 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
   </section>
 
   <section xml:id="sec-trento-problemanalysis">
-    <title>Problem Analysis in a K8s; scenario</title>
+    <title>Problem Analysis</title>
     <para>
-      This section covers some common problems and how to analyze them in a K8s; scenario.
+      This section covers some common problems and how to analyze them.
     </para>
 
     <section>
       <title>&t.server;</title>
-      <para>To analyze issues within the application, we have two tools at our
+      <para>To analyze issues &t.server; in a &K8s; scenario, we have two tools at our
         disposal. They both help us collect information/data that might be
         useful when troubleshooting/analyzing the issue.</para>
 

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2444,7 +2444,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
      or through the corresponding vendor, depending on their licensing model. Problems must be reported under &sles4sap;&nbsp;15 and component trento.
     </para>
       <para>
-      When opening a support case for Trento, provide the chosen deployment option for &t.server;: &K8s;, systemd or containeraized.</para>
+      When opening a support case for Trento, provide the chosen deployment option for &t.server;: &K8s;, systemd or containerized.</para>
    <para>In the case of a &K8s; deployment, provide also the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
     </para>
    <para>In the case of a systemd deployment, provide the status and the journal of the trento-web and trento-wanda services.

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2441,20 +2441,17 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
     <para>
       Any &suse; customer, with a registered &sles4sap;&nbsp;15 (SP1 or higher) distribution,
      experiencing an issue with &trentopremium;, can report the problem either directly in the &scc;
-     or through the corresponding vendor, depending on their licensing model. Please report the problem under &sles4sap;&nbsp;15 and component trento.
+     or through the corresponding vendor, depending on their licensing model. Problems must be reported under &sles4sap;&nbsp;15 and component trento.
     </para>
       <para>
-      When opening a support case for Trento, provide the following information, which can be retrieved
-     as explained in section <xref linkend="sec-trento-problemanalysis" />:
+      When opening a support case for Trento, provide the chosen deployment option for &t.server;: &K8s;, systemd or containeraized.</para>
+   <para>In the case of a &K8s; deployment, provide also the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
     </para>
-         <itemizedlist>
-          <listitem>
-            <para>The output of the Trento support plugin.</para>
-          </listitem>
-           <listitem>
-            <para>Your scenario dump.</para>
-          </listitem>
-        </itemizedlist>
+   <para>In the case of a systemd deployment, provide the status and the journal of the trento-web and trento-wanda services.
+    </para>
+   <para>Finally, in the case of a containerized deployment, provide the logs of the trento-web and trento-wanda containers. Use docker ps to retrieve
+    the IDs of both containers, then docker logs <container_id> to retrieve the corresponding logs.
+    </para>
    <para>
       For issues with a particular &t.agent;, or a component discovered by a particular &t.agent;, also provide the following:
     </para>
@@ -2475,9 +2472,9 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
   </section>
 
   <section xml:id="sec-trento-problemanalysis">
-    <title>Problem Analysis</title>
+    <title>Problem Analysis in a K8s; scenario</title>
     <para>
-      This section covers some common problems and how to analyze them.
+      This section covers some common problems and how to analyze them in a K8s; scenario.
     </para>
 
     <section>

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2444,13 +2444,13 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
      or through the corresponding vendor, depending on their licensing model. Problems must be reported under &sles4sap;&nbsp;15 and component trento.
     </para>
       <para>
-      When opening a support case for Trento, provide the chosen deployment option for &t.server;: &K8s;, systemd or containerized.</para>
-   <para>In case of a &K8s; deployment, provide the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
+      When opening a support case for Trento, provide the chosen deployment option for &t.server;: &k8s;, systemd or containerized.</para>
+   <para>In case of a &k8s; deployment, provide the output of the Trento support plugin and the scenario dump, as explained in section <xref linkend="sec-trento-problemanalysis" />.
     </para>
    <para>In case of a systemd deployment, provide the status and the journal of the trento-web and trento-wanda services.
     </para>
    <para>In case of a containerized deployment, provide the logs of the trento-web and trento-wanda containers. Use <command>docker ps</command> to retrieve
-    the IDs of both containers, then <command>docker logs <replaceable>CONTAINER_ID</replaceable> to retrieve the corresponding logs.
+    the IDs of both containers, then <command>docker logs <replaceable>CONTAINER_ID</replaceable></command> to retrieve the corresponding logs.
     </para>
    <para>
       For issues with a particular &t.agent;, or a component discovered by a particular &t.agent;, also provide the following:
@@ -2479,7 +2479,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
     <section>
       <title>&t.server;</title>
-      <para>There are two tools you can use to analyze issues with &t.server; in a &K8s; scenario. They both help us collect information/data that might be
+      <para>There are two tools you can use to analyze issues with &t.server; in a &k8s; scenario. They both help us collect information/data that might be
         useful when troubleshooting/analyzing the issue.</para>
 
       <section>


### PR DESCRIPTION
This PR is to be reviewed and merged/published right away. No need to wait for the next version of Trento.

It extends section Reporting a Problem to the systemd and containerized scenario. It also clarifies that the Trento Support Plugin and the Scenario dump scripts are specific to the Kubernetes deployment
