### PR TITLE
Minor corrections before release of new version

### DIFF
--- a/trento/migration/systemd-install.md
+++ b/trento/migration/systemd-install.md
@@ -435,11 +435,6 @@ Expected output if Trento web/wanda is ready and the database connection is setu
 
    If there are issues with the configuration, the output will indicate what needs to be adjusted.
 
-1. If SSL certificates were modified or added, reload NGINX to apply the changes.
-
-   ```bash
-   systemctl reload nginx
-   ```
 
 ## Prepare SSL certificate for NGINX
 

--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2402,7 +2402,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
 
    <section xml:id="sec-trento-uninstall-trentoserver">
     <title>Uninstalling &t.server;</title>
-    <para>The procedure to update the Trento Server depends on the deployment type: Kubernetes, systemd or containerized. The section covers Kubernetes deployments.</para>
+    <para>The procedure to uninstall the Trento Server depends on the deployment type: Kubernetes, systemd or containerized. The section covers Kubernetes deployments.</para>
     <para> If &t.server; was deployed manually, then you need to uninstall it manually.
      If  &t.server; was deployed using the Helm chart, you can also use Helm to uninstall it as follows:</para>
      <screen>helm uninstall trento-server</screen>

--- a/trento/xml/systemd-install.xml
+++ b/trento/xml/systemd-install.xml
@@ -672,14 +672,6 @@ nginx: configuration file /etc/nginx/nginx.conf test is successful
           adjusted.
         </para>
       </step>
-      <step>
-        <para>
-          If SSL certificates were modified or added, reload NGINX to apply changes:
-        </para>
-<programlisting language="bash">
-systemctl reload nginx
-</programlisting>
-      </step>
     </procedure>
   </section>
   <section xml:id="prepare-ssl-certificate-for-nginx">


### PR DESCRIPTION
Just a couple of minor corrections before the release of the new version of Trento: 1) In the Uninstall section replace "update" with "uninstall" 2) In the systemd deployment section, removal of the first nginx reload step since the certificate does not exist yet and the reload will make nginx crash.

To be reviewed, merged and published ASAP.