### PR TITLE
Containers Module required to install the Trento SupportConfig Plugin

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -2516,6 +2516,7 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
               <para>Customers of &sles4sap; 15 SP3 and higher can install the
                   <package>trento-supportconfig-plugin</package> package
                 directly from the official &sles4sapa; 15 repos using &zypper;.
+               The Containers Module is required for installation.
               </para>
             </note>
           </step>


### PR DESCRIPTION
Containers Module required to install the Trento SupportConfig Plugin
