### PR TITLE
Add operations endpoint nginx rule

### DIFF
--- a/trento/migration/systemd-install.md
+++ b/trento/migration/systemd-install.md
@@ -387,7 +387,7 @@ Expected output if Trento web/wanda is ready and the database connection is setu
        ssl_session_cache shared:SSL:10m;
 
        # Wanda rule
-       location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks)/  {
+       location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks|api/groups|api/v1/groups|api/operations|api/v1/operations)/  {
            allow all;
 
            # Proxy Headers

--- a/trento/xml/systemd-install.xml
+++ b/trento/xml/systemd-install.xml
@@ -621,7 +621,7 @@ server {
     ssl_session_cache shared:SSL:10m;
 
     # Wanda rule
-    location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks)/  {
+    location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks|api/groups|api/v1/groups|api/operations|api/v1/operations)/  {
         allow all;
 
         # Proxy Headers


### PR DESCRIPTION
### PR creator: Description

Add new `/api/v1/groups` and `/api/v1/operations` endpoints nginx rule to nginx configuration.

**To be merged once we have release `2.5.0` ready**.
The operations part might not be really needed there, but well, it is not harmful and we just have some work done in advance.
If we want to be super picky, we can remove the operations part and it after 2.5.0 release
