### PR TITLE
SUMA to SUSE Multi-Linux Manager workaround

### DIFF
--- a/trento/xml/article_sap_trento.xml
+++ b/trento/xml/article_sap_trento.xml
@@ -288,14 +288,14 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
     </section>
 
   <section xml:id="sec-integration-with-SUSE-Manager">
-      <title>Integration with &suma;</title>
-      <para>Trento integrates with &suma; to provide the &sap; administrator with
+      <title>Integration with SUSE Multi-Linux Manager</title>
+      <para>Trento integrates with SUSE Multi-Linux Manager to provide the &sap; administrator with
       information about relevant patches and upgradable packages for any host
        that is registered with both applications.</para>
-      <para>The user must enter the connection settings for &suma;
+      <para>The user must enter the connection settings for SUSE Multi-Linux Manager
        in the <guimenu>Settings</guimenu> view:</para>
      <figure>
-         <title>&suma; settings</title>
+         <title>SUSE Multi-Linux Manager settings</title>
         <mediaobject>
           <imageobject>
             <imagedata
@@ -304,10 +304,10 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
         </mediaobject>
       </figure>
    <para>
-   Once the &suma; settings are configured, the &sap; Basis administrator can test the connection
+   Once the SUSE Multi-Linux Manager settings are configured, the &sap; Basis administrator can test the connection
    by clicking the <guimenu>Test</guimenu> button.
    If the connection is successful, the <guimenu>Host Details</guimenu> view of each host
-   managed by &suma; displays a summary
+   managed by SUSE Multi-Linux Manager displays a summary
    of available patches and upgradable packages:</para>
         <figure>
          <title><guimenu>Availale software updates in the Host Details view</guimenu></title>
@@ -354,10 +354,10 @@ In the Trento dashboard, go to the overview corresponding to the object for whic
    enhancements. Security advisories are regarded as critical. If one is avaiable,
    the health of the host will be set to critical. If there are available patches but none of them
     is a security one, the health of the host will switch to warning. When a host cannot be found in
-    &suma; or there is a problem retrieving the data for it, its health is set as unknnown.
+    SUSE Multi-Linux Manager or there is a problem retrieving the data for it, its health is set as unknnown.
    </para>
     <para>
-    At any time, the user can clear the &suma; settings from the Settings view.
+    At any time, the user can clear the SUSE Multi-Linux Manager settings from the Settings view.
     As a result, all information about available software updates disappears from the console and the status of the hosts is adjusted accordingly.</para>
     </section>
 
@@ -1438,7 +1438,7 @@ trento-server-rabbitmq-0</screen>
               <para>SSO and third-party IDP integration via OIDC, OAUTH2 and SAML protocols.</para>
             </listitem>
                                   <listitem>
-              <para>Contextual, detailed overview of available patches and upgradable packages in the SUSE Manager integration.</para>
+              <para>Contextual, detailed overview of available patches and upgradable packages in the SUSE Multi-Linux Manager integration.</para>
             </listitem>
                                   <listitem>
               <para>Inception of the Activity Log, allowing users to browse a single centralized event log for their entire SAP landscape.</para>
@@ -1488,7 +1488,7 @@ trento-server-rabbitmq-0</screen>
             <listitem>
               <para>
                Information about available patches and upgradable packages for each registered hosts via integration
-               with SUSE manager.</para>
+               with SUSE Multi-Linux Manager.</para>
             </listitem>
                        <listitem>
               <para>Rotating API key.</para>

--- a/trento/xml/html/rh-article-trento.html
+++ b/trento/xml/html/rh-article-trento.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Getting Started with Trento (Getting Started with Trento)</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History"/>
-<meta name="description" content="Initial version"/>
+<meta name="description" content="Revision History: Initial version"/>
 <meta name="book-title" content="Getting Started with Trento"/>
 <meta name="chapter-title" content="Revision History"/>
 <meta name="tracker-url" content="https://bugzilla.suse.com/enter_bug.cgi"/>
@@ -64,24 +64,7 @@
       }
     }
   }</script>
-<script type="text/javascript">
-
-if ( window.location.protocol.toLowerCase() != 'file:' ) {
-  document.write('<link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"></link>');
-};
-
-</script><noscript><link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"/></noscript><script src="static/js/script-purejs.js" type="text/javascript"> </script><script src="static/js/highlight.min.js" type="text/javascript"> </script><script>
-
-$(document).ready(function() {
-  $('.verbatim-wrap.highlight').each(function(i, block) {
-    hljs.highlightBlock(block);
-  });
-});
-hljs.configure({
-  useBR: false
-});
-
-</script></head><body><div class="revhistory" id="rh-article-trento"><h1 class="title">Revision History: Getting Started with Trento</h1><section class="revision"><h2><span class="revision date">2021-12-10</span></h2>
+<link type="text/css" rel="preload" as="style" onload="this.rel='stylesheet'" href="https://documentation.suse.com/docserv/res/fonts/suse/suse.css"/><script src="static/js/script-purejs.js" type="text/javascript"> </script><script src="static/js/highlight.js" type="text/javascript"> </script><script>hljs.highlightAll();</script></head><body><div class="revhistory" id="rh-article-trento"><h1 class="title">Revision History: Getting Started with Trento</h1><section class="revision"><h2><span class="revision date">2021-12-10</span></h2>
         <p>
           Initial version
         </p>

--- a/trento/xml/trento-intro.xml
+++ b/trento/xml/trento-intro.xml
@@ -65,7 +65,7 @@
       </listitem>
               <listitem>
         <para>
-          Information about relevant patches and upgradable packages for registered hosts via integration with &suma;.
+          Information about relevant patches and upgradable packages for registered hosts via integration with SUSE Multi-Linux Manager.
         </para>
       </listitem>
       <listitem>

--- a/trento/xml/trento-web-console.xml
+++ b/trento/xml/trento-web-console.xml
@@ -298,8 +298,8 @@ The health boxes in the dashboard are clickable. Clicking on a box filters the d
                <listitem>
                 <para>Available software updates section shows a summary of the
                 available patches and upgradable packages for the current host
-                when settings for &suma; are maintained and the host is managed
-                by the &suma; instance for which connection data has been
+                when settings for SUSE Multi-Linux Manager are maintained and the host is managed
+                by the SUSE Multi-Linux Manager instance for which connection data has been
                 provided. Refer to section
                 <xref linkend="sec-integration-with-SUSE-Manager"/> for further details. </para>
               </listitem>


### PR DESCRIPTION
### PR creator: Description

A temporary workaround that replaces SUMA with SUSE Multi-Linux Manager until a new version of dic-kit is ready.