### PR TITLE
PCIDSS: SuMa to SMLM

### DIFF
--- a/pcidss/xml/art_security_pcidss.xml
+++ b/pcidss/xml/art_security_pcidss.xml
@@ -534,9 +534,9 @@
         Default settings can be customized by automating system installation
         with an &ay; profile. This allows rolling out new instances of
         &productnamex; and automatically enabling an evaluated configuration.
-        This setup procedure can also be automated with the &susemgr;. For
-        more information, see the &susemgr; documentation at
-        <link xlink:href="https://documentation.suse.com/suma/"/>.
+        This setup procedure can also be automated with the &smlm;. For
+        more information, see the &smlm; documentation at
+        <link xlink:href="https://documentation.suse.com/multi-linux-manager/"/>.
        </para>
        <para>
         By default, &productnamex; does not create additional accounts
@@ -1009,7 +1009,7 @@
      </listitem>
      <listitem>
       <para>
-       For system management, &suse; provides &susemgr;, which provides an
+       For system management, &suse; provides &smlm;, which provides an
        efficient way to keep systems up-to-date. It offers seamless
        management of both &productnamex; and &rhel; client systems. This
        is particularly useful in larger system environments, when you need to
@@ -1017,8 +1017,8 @@
        security risks.
       </para>
       <para>
-       For information about &susemgr;, see the
-       <link xlink:href="https://documentation.suse.com/suma/">&susemgr;
+       For information about &smlm;, see the
+       <link xlink:href="https://documentation.suse.com/multi-linux-manager/">&smlm;
        documentation page</link>.
       </para>
      </listitem>


### PR DESCRIPTION
With the upcoming version 5.1, **SUSE Manager** will be renamed to **SUSE Multi-Linux Manager** (already released SuMa versions keep their name and their documentation URLs).

The unversioned docs also should reflect the product name change. 

Also, the 'generic' URL `https://documentation.suse.com/suma` (which always redirects to the docs for the latest released SuMa version) will be replaced with `https://documentation.suse.com/multi-linux-manager` moving forward.


### PR creator: Are there any relevant issues/feature requests?

https://jira.suse.com/browse/DOCTEAM-1754