### PR TITLE
suseconnect: SuMa to SMLM

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -79,7 +79,7 @@
       &suse; is committed to helping provide better insights into the
       consumption of SUSE subscriptions, regardless of where they are running or
       how they are managed; physical or virtual, on-premises or in the cloud,
-      connected to SCC or RMT, or managed by SUSE Manager. To help you identify
+      connected to SCC or RMT, or managed by &smlm;. To help you identify
       or filter out systems in SCC that are decommissioned or no longer running,
       &suseconnect; now features a daily <quote>ping,</quote> which updates
       system information automatically. Each registered host contacts SCC or RMT
@@ -187,7 +187,7 @@
     <para>
       When &suseconnect; reports details about active hosts daily, SCC or RMT
       collect this information and let you filter out registered inactive hosts.
-      If your hosts are registered against RMT or &suma;, these registration
+      If your hosts are registered against RMT or &smlm;, these registration
       servers forward the received information to SCC.
     </para>
 
@@ -253,7 +253,7 @@
 
     <para>
       When a system is registered directly via SCC, or its registration
-      information is forwarded by RMT or &suma;, SCC collects the following
+      information is forwarded by RMT or &smlm;, SCC collects the following
       information:
     </para>
 
@@ -379,7 +379,7 @@
 
     <tip>
       <para>
-        &susemgr; sends additional data about the used hypervisor and
+        &smlm; sends additional data about the used hypervisor and
         virtualized systems. Find more details in
         <link
         xlink:href="https://documentation.suse.com/subscription/hypervisor-collector/html/SLE-scc-hypervisor-collector/index.html#scc-hypervisor-collector-data"/>.
@@ -448,8 +448,8 @@
       </listitem>
       <listitem>
         <para>
-          Find further information about &suma; at
-          <link xlink:href="https://documentation.suse.com/suma/"/>
+          Find further information about &smlm; at
+          <link xlink:href="https://documentation.suse.com/multi-linux-manager/"/>
         </para>
       </listitem>
     </itemizedlist>


### PR DESCRIPTION
With the upcoming version 5.1, **SUSE Manager** will be renamed to **SUSE Multi-Linux Manager** (already released SuMa versions keep their name and their documentation URLs).

The unversioned docs also should reflect the product name change. 

Also, the 'generic' URL `https://documentation.suse.com/suma` (which always redirects to the docs for the latest released SuMa version) will be replaced with `https://documentation.suse.com/multi-linux-manager` moving forward.


### PR creator: Are there any relevant issues/feature requests?

https://jira.suse.com/browse/DOCTEAM-1754
