### PR TITLE
SLES for SAP applications: fix productname spelling

### DIFF
--- a/sap-ha-support/xml/product-entities.ent
+++ b/sap-ha-support/xml/product-entities.ent
@@ -2,7 +2,7 @@
 <!-- This file can be edited downstream. -->
 
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname            "&slsa; for &sap; Applications">
+<!ENTITY productname            "&slsa; for &sap; applications">
 <!ENTITY productnameshort       "&s4sa;">
 <!ENTITY product-ga             "15">
 <!ENTITY product-sp             "Code stream">


### PR DESCRIPTION
### PR creator: Description

SLES for SAP Applications ->  SLES for SAP applications (on request of the product manager). 

I thought we had fixed this with https://github.com/openSUSE/doc-kit/pull/108 and the doc-kit run afterwards, but by chance I spotted the 'old' spelling in the PDF and saw that another entity from `product-entities.ent` was used here (which is product-specific and not under doc-kit control). Hence this PR.

