### PR TITLE
Add vendor to suseconnect collection info

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -325,7 +325,7 @@
             <entry>Linux lair 6.9.7-1-default #1 SMP PREEMPT_DYNAMIC Fri Jun 28 05:50:47 UTC 2024 (a5efffa) x86_64 x86_64 x86_64 GNU/Linux</entry>
           </row>
           <row>
-            <entry>vendor</entry>
+            <entry>Vendor</entry>
             <entry>string</entry>
             <entry>Hardware manufacturer for the system. For virtual machines this will be the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
           </row>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -327,7 +327,7 @@
           <row>
             <entry>Vendor</entry>
             <entry>string</entry>
-            <entry>Hardware manufacturer for the system. For virtual machines this will be the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
+            <entry>Hardware manufacturer for the system. For virtual machines this is the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
           </row>
           <row>
             <entry>Architecture specifics</entry>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -325,6 +325,11 @@
             <entry>Linux lair 6.9.7-1-default #1 SMP PREEMPT_DYNAMIC Fri Jun 28 05:50:47 UTC 2024 (a5efffa) x86_64 x86_64 x86_64 GNU/Linux</entry>
           </row>
           <row>
+            <entry>vendor</entry>
+            <entry>string</entry>
+            <entry>Hardware manufacturer for the system. For virtual machines this will be the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
+          </row>
+          <row>
             <entry>Architecture specifics</entry>
             <entry>map</entry>
             <entry>Depends on the architecture. It includes parameters such as device-tree information or virtualization type on PowerPC or System Z.</entry>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -45,6 +45,14 @@
       <phrase>Subscription Management</phrase>
     </meta>
     <revhistory xml:id="rh-article-suseconnect-visibility">
+    <revision>
+        <date>2026-03-25</date>
+        <revdescription>
+          <para>
+            Added 'Vendor' to the table of collected system attributes
+          </para>
+        </revdescription>
+      </revision>
       <revision>
         <date>2026-03-03</date>
         <revdescription>


### PR DESCRIPTION
### PR creator: Description

Add details about the collection of vendor/manufacturer information for SLE systems registered with suseconnect.
This data will be reported on system registration and as part of the regular system heartbeat.


### PR creator: Are there any relevant issues/feature requests?

* SCC-571
* TEL-260
* SCC-505
* SCC-570
### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
