### PR TITLE
Add ha_active to SUSEConnect collection info

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -54,6 +54,15 @@
         </revdescription>
       </revision>
       <revision>
+    <revision>
+        <date>2026-06-02</date>
+        <revdescription>
+          <para>
+            Added 'ha_active' to the table of collected system attributes
+          </para>
+        </revdescription>
+      </revision>
+    <revision>
         <date>2026-03-25</date>
         <revdescription>
           <para>
@@ -347,6 +356,11 @@
             <entry>Vendor</entry>
             <entry>string</entry>
             <entry>Hardware manufacturer for the system. For virtual machines this is the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
+          </row>
+          <row>
+            <entry>ha_active</entry>
+            <entry>string</entry>
+            <entry>the pacemaker version, if the pacemaker.service is running on the client, for example 2.1.10+20250718.fdf796ebc8-150700.3.3.1</entry>
           </row>
           <row>
             <entry>Architecture specifics</entry>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -360,7 +360,7 @@
           <row>
             <entry>ha_active</entry>
             <entry>string</entry>
-            <entry>the pacemaker version, if the pacemaker.service is running on the client, for example 2.1.10+20250718.fdf796ebc8-150700.3.3.1</entry>
+            <entry>The pacemaker version, if the `pacemaker.service` is running on the client. For example, 2.1.10+20250718.fdf796ebc8-150700.3.3.1</entry>
           </row>
           <row>
             <entry>Architecture specifics</entry>


### PR DESCRIPTION
### PR creator: Description

Document ha_active data that will be collected by suseconnect.
ha_active set to the pacemaker version if the is included in the system running the pacemaker service.


### PR creator: Are there any relevant issues/feature requests?

* SCC-695
* CC-693
* SCC-426
* SCC-733

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
