### PR TITLE
Add Kubernetes Provider entry to suseconnect visibility

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -46,7 +46,15 @@
       <phrase>Subscription Management</phrase>
     </meta>
     <revhistory xml:id="rh-article-suseconnect-visibility">
-    <revision>
+      <revision>
+        <date>2026-05-20</date>
+        <revdescription>
+          <para>
+            Added 'kubernetes_provider' to the table of collected system attributes
+          </para>
+        </revdescription>
+      </revision>
+      <revision>
         <date>2026-03-25</date>
         <revdescription>
           <para>
@@ -362,6 +370,22 @@
       ]
     }
 ]
+</screen>
+            </entry>
+          </row>
+          <row>
+            <entry>Kubernetes Provider</entry>
+            <entry>map</entry>
+            <entry>
+             <para>
+	       <literal>role</literal> (string), <literal>type</literal> (string), and <literal>version</literal> (string) when a recognised Kubernetes provider is detected.
+             </para>
+<screen>
+"kubernetes_provider": {
+  "role": "server",
+  "type": "rke2",
+  "version": "v1.35.4+rke2r1"
+}
 </screen>
             </entry>
           </row>


### PR DESCRIPTION
### PR creator: Description

Add an entry for the new kubernetes provider item to the list of what is collected from systems.

### PR creator: Are there any relevant issues/feature requests?

* jsc#TEL-319

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
