### PR TITLE
Adds Opt In/Out entry to suseconnect visibility

### DIFF
--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -49,12 +49,12 @@
         <date>2026-06-08</date>
         <revdescription>
           <para>
-            Added information about collector configuration and opt-in/opt-out capabilities for optional collectors. 
-            Updated configuration format documentation to reflect transition from line-by-line format to YAML-based configuration
+            Added information about collector configuration and opt-in/opt-out capabilities for optional collectors.
+            Updated configuration format documentation to reflect transition from line-by-line format to YAML-based configuration.
           </para>
         </revdescription>
       </revision>  
-      <revision>  
+      <revision>
         <date>2026-06-02</date>
         <revdescription>
           <para>
@@ -303,17 +303,15 @@
 
     <table>
       <title>System attributes collected by SCC</title>
-      <tgroup cols='4' align='left'>
+      <tgroup cols='3' align='left'>
         <colspec colnum="1" colname="1" colwidth=""/>
         <colspec colnum="2" colname="2" colwidth=""/>
-        <colspec colnum="3" colname="3" colwidth="2*"/>
-        <colspec colnum="4" colname="4" colwidth="1*"/>
+        <colspec colnum="3" colname="3" colwidth="3*"/>
         <thead>
           <row>
             <entry>System Attribute</entry>
             <entry>Type</entry>
             <entry>Example value</entry>
-            <entry>Configurable</entry>
           </row>
         </thead>
         <tbody>
@@ -321,61 +319,51 @@
             <entry>Host Name</entry>
             <entry>string</entry>
             <entry>virtual.domain.net</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>CPUs</entry>
             <entry>int</entry>
             <entry>1</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Sockets</entry>
             <entry>int</entry>
             <entry>2</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Total Memory</entry>
             <entry>int</entry>
             <entry>4096 (in MiB)</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Architecture</entry>
             <entry>string</entry>
             <entry>x86_64</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>UUID</entry>
             <entry>uuid</entry>
             <entry>6A5072A0-311B-430E-8EDE-A8770788B92D</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Hypervisor</entry>
             <entry>string</entry>
             <entry>KVM or VMware etc.</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Container runtime</entry>
             <entry>string</entry>
             <entry>Docker</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>uname</entry>
             <entry>string</entry>
             <entry>Linux lair 6.9.7-1-default #1 SMP PREEMPT_DYNAMIC Fri Jun 28 05:50:47 UTC 2024 (a5efffa) x86_64 x86_64 x86_64 GNU/Linux</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Vendor</entry>
             <entry>string</entry>
             <entry>Hardware manufacturer for the system. For virtual machines this is the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>ha_active</entry>
@@ -386,7 +374,6 @@
             <entry>Architecture specifics</entry>
             <entry>map</entry>
             <entry>Depends on the architecture. It includes parameters such as device-tree information or virtualization type on PowerPC or System Z.</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>SAP</entry>
@@ -407,7 +394,6 @@
 ]
 </screen>
             </entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Kubernetes Provider</entry>
@@ -424,19 +410,16 @@
 }
 </screen>
             </entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Cloud Provider</entry>
             <entry>string</entry>
             <entry>Amazon, Google, or Azure</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Last Seen Date</entry>
             <entry>date</entry>
             <entry>2021-05-05 (the last time that the system contacted SCC or &rmt;)</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Products</entry>
@@ -454,13 +437,11 @@
 }
 </screen>
             </entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>Subscriptions</entry>
             <entry>list</entry>
             <entry>The subscription registration code used to activate each product</entry>
-            <entry>No</entry>
           </row>
           <row>
             <entry>pci_data</entry>
@@ -480,7 +461,6 @@
 }
 </screen>
             </entry>
-            <entry>Yes</entry>
           </row>
           <row>
             <entry>mod_list</entry>
@@ -501,7 +481,6 @@
 }
 </screen>
             </entry>
-            <entry>Yes</entry>
           </row>
         </tbody>
       </tgroup>
@@ -520,7 +499,9 @@
       <title>Configuring system data collectors</title>
 
       <para>
-        &suseconnect; collects system data through a configurable collector system. Most collectors are mandatory and cannot be disabled, as they provide essential system information required for proper subscription management and support. However, certain optional collectors can be configured to suit your privacy and performance requirements.
+        &suseconnect; collects system data through a configurable collector system.
+        Most collectors are mandatory and cannot be disabled, as they provide essential system information required for proper subscription management and support.
+        However, certain optional collectors can be configured to suit your privacy and performance requirements.
       </para>
 
       <sect3 xml:id="mandatory-collectors">
@@ -590,7 +571,8 @@
           <title>Collector configuration</title>
 
           <para>
-            To configure optional collectors, edit the &suseconnect; configuration file at <filename>/etc/SUSEConnect</filename>. Add a <literal>collectors</literal> section with the desired collector configuration:
+            To configure optional collectors, edit the &suseconnect; configuration file at <filename>/etc/SUSEConnect</filename>.
+            Add a <literal>collectors</literal> section with the desired collector configuration:
           </para>
 
 <screen>
@@ -624,7 +606,8 @@ collectors:
 
           <note>
             <para>
-              If a collector is not configured in the file, it will use its default state (enabled for optional collectors). When a collector is disabled, &suseconnect; will not collect that data when contacting SCC or &rmt;.
+              If a collector is not configured in the file, it will use its default state.
+              When a collector is disabled, &suseconnect; will not collect or relay that data when contacting SCC or &rmt;.
             </para>
           </note>
         </sect4>

--- a/suseconnect-visibility/xml/art_suseconnect_visibility.xml
+++ b/suseconnect-visibility/xml/art_suseconnect_visibility.xml
@@ -46,6 +46,14 @@
     </meta>
     <revhistory xml:id="rh-article-suseconnect-visibility">
       <revision>
+        <date>2026-06-02</date>
+        <revdescription>
+          <para>
+            Added information about collector configuration and opt-in/opt-out capabilities for optional collectors. Updated configuration format documentation to reflect transition from line-by-line format to YAML-based configuration
+          </para>
+        </revdescription>
+      </revision>
+      <revision>
         <date>2026-05-20</date>
         <revdescription>
           <para>
@@ -286,15 +294,17 @@
 
     <table>
       <title>System attributes collected by SCC</title>
-      <tgroup cols='3' align='left'>
+      <tgroup cols='4' align='left'>
         <colspec colnum="1" colname="1" colwidth=""/>
         <colspec colnum="2" colname="2" colwidth=""/>
-        <colspec colnum="3" colname="3" colwidth="3*"/>
+        <colspec colnum="3" colname="3" colwidth="2*"/>
+        <colspec colnum="4" colname="4" colwidth="1*"/>
         <thead>
           <row>
             <entry>System Attribute</entry>
             <entry>Type</entry>
             <entry>Example value</entry>
+            <entry>Configurable</entry>
           </row>
         </thead>
         <tbody>
@@ -302,56 +312,67 @@
             <entry>Host Name</entry>
             <entry>string</entry>
             <entry>virtual.domain.net</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>CPUs</entry>
             <entry>int</entry>
             <entry>1</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Sockets</entry>
             <entry>int</entry>
             <entry>2</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Total Memory</entry>
             <entry>int</entry>
             <entry>4096 (in MiB)</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Architecture</entry>
             <entry>string</entry>
             <entry>x86_64</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>UUID</entry>
             <entry>uuid</entry>
             <entry>6A5072A0-311B-430E-8EDE-A8770788B92D</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Hypervisor</entry>
             <entry>string</entry>
             <entry>KVM or VMware etc.</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Container runtime</entry>
             <entry>string</entry>
             <entry>Docker</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>uname</entry>
             <entry>string</entry>
             <entry>Linux lair 6.9.7-1-default #1 SMP PREEMPT_DYNAMIC Fri Jun 28 05:50:47 UTC 2024 (a5efffa) x86_64 x86_64 x86_64 GNU/Linux</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Vendor</entry>
             <entry>string</entry>
             <entry>Hardware manufacturer for the system. For virtual machines this is the hypervisor. A sample of the possible values would be Dell Inc., IBM, HP, QEMU, ...</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Architecture specifics</entry>
             <entry>map</entry>
             <entry>Depends on the architecture. It includes parameters such as device-tree information or virtualization type on PowerPC or System Z.</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>SAP</entry>
@@ -372,6 +393,7 @@
 ]
 </screen>
             </entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Kubernetes Provider</entry>
@@ -388,16 +410,19 @@
 }
 </screen>
             </entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Cloud Provider</entry>
             <entry>string</entry>
             <entry>Amazon, Google, or Azure</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Last Seen Date</entry>
             <entry>date</entry>
             <entry>2021-05-05 (the last time that the system contacted SCC or &rmt;)</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Products</entry>
@@ -415,11 +440,13 @@
 }
 </screen>
             </entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>Subscriptions</entry>
             <entry>list</entry>
             <entry>The subscription registration code used to activate each product</entry>
+            <entry>No</entry>
           </row>
           <row>
             <entry>pci_data</entry>
@@ -439,6 +466,7 @@
 }
 </screen>
             </entry>
+            <entry>Yes</entry>
           </row>
           <row>
             <entry>mod_list</entry>
@@ -459,6 +487,7 @@
 }
 </screen>
             </entry>
+            <entry>Yes</entry>
           </row>
         </tbody>
       </tgroup>
@@ -472,6 +501,121 @@
         xlink:href="https://documentation.suse.com/subscription/hypervisor-collector/html/SLE-scc-hypervisor-collector/index.html#scc-hypervisor-collector-data"/>.
       </para>
     </tip>
+
+    <sect2 xml:id="configuring-collectors">
+      <title>Configuring system data collectors</title>
+
+      <para>
+        &suseconnect; collects system data through a configurable collector system. Most collectors are mandatory and cannot be disabled, as they provide essential system information required for proper subscription management and support. However, certain optional collectors can be configured to suit your privacy and performance requirements.
+      </para>
+
+      <sect3 xml:id="mandatory-collectors">
+        <title>Mandatory collectors</title>
+
+        <para>
+          The following collectors are always enabled and cannot be disabled:
+        </para>
+
+        <itemizedlist>
+          <listitem>
+            <para>Host Name</para>
+          </listitem>
+          <listitem>
+            <para>CPUs, Sockets, and Total Memory</para>
+          </listitem>
+          <listitem>
+            <para>Architecture</para>
+          </listitem>
+          <listitem>
+            <para>UUID</para>
+          </listitem>
+          <listitem>
+            <para>Hypervisor</para>
+          </listitem>
+          <listitem>
+            <para>Container runtime</para>
+          </listitem>
+          <listitem>
+            <para>uname (kernel version and OS details)</para>
+          </listitem>
+          <listitem>
+            <para>Vendor (hardware manufacturer)</para>
+          </listitem>
+          <listitem>
+            <para>Architecture specifics</para>
+          </listitem>
+          <listitem>
+            <para>SAP workload detection</para>
+          </listitem>
+          <listitem>
+            <para>Kubernetes Provider detection</para>
+          </listitem>
+          <listitem>
+            <para>Cloud Provider</para>
+          </listitem>
+        </itemizedlist>
+      </sect3>
+
+      <sect3 xml:id="optional-collectors">
+        <title>Optional collectors</title>
+
+        <para>
+          The following collectors are enabled by default but can be disabled through configuration:
+        </para>
+
+        <itemizedlist>
+          <listitem>
+            <para><literal>pci_data</literal> — PCI device information</para>
+          </listitem>
+          <listitem>
+            <para><literal>mod_list</literal> — Loaded kernel modules</para>
+          </listitem>
+        </itemizedlist>
+
+        <sect4 xml:id="collector-configuration-file">
+          <title>Collector configuration</title>
+
+          <para>
+            To configure optional collectors, edit the &suseconnect; configuration file at <filename>/etc/SUSEConnect</filename>. Add a <literal>collectors</literal> section with the desired collector configuration:
+          </para>
+
+<screen>
+---
+url: https://scc.suse.com
+language: en
+insecure: false
+auto_agree_with_licenses: false
+enable_system_uptime_tracking: false
+no_zypper_refs: false
+
+collectors:
+  pci_data:
+    state: disabled
+  mod_list:
+    state: disabled
+</screen>
+
+          <para>
+            For each optional collector, set the <literal>state</literal> field to one of the following:
+          </para>
+
+          <itemizedlist>
+            <listitem>
+              <para><literal>enabled</literal> — Enable the collector (default)</para>
+            </listitem>
+            <listitem>
+              <para><literal>disabled</literal> — Disable the collector</para>
+            </listitem>
+          </itemizedlist>
+
+          <note>
+            <para>
+              If a collector is not configured in the file, it will use its default state (enabled for optional collectors). When a collector is disabled, &suseconnect; will not collect that data when contacting SCC or &rmt;.
+            </para>
+          </note>
+        </sect4>
+      </sect3>
+    </sect2>
   </sect1>
   <sect1 xml:id="suseconnect-benefits">
     <title>What are the benefits of using the keep-alive timer?</title>


### PR DESCRIPTION
### PR creator: Description

Add a new entry for the Opt In / Out feature.
The revision includes the YAML parser changes, examples, and a new section on how to customize optional collectors enablement.

### PR creator: Are there any relevant issues/feature requests?

* jsc#TEL-314

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
