### PR TITLE
container-guide: rebrand SLE BCI → SUSE Linux BCI

### DIFF
--- a/container-guide/common/product-entities.ent
+++ b/container-guide/common/product-entities.ent
@@ -34,3 +34,12 @@
 <!ENTITY amdsev                  "AMD SEV">
 <!ENTITY ansible                 "Ansible">
 <!ENTITY kea                     "Kea">
+
+<!-- Override BCI entities defined in generic-entities.ent so this product
+     uses the current "SUSE Linux BCI" branding instead of the legacy
+     "SLE BCI" form. XML entity resolution uses first-definition-wins, and
+     product-entities.ent is included by generic-entities.ent before its own
+     bci/bcia/bci-product definitions, so the overrides below take effect. -->
+<!ENTITY bci-product             "&suselinux; Base Container Images">
+<!ENTITY bci                     "&suselinux; Base Container Image">
+<!ENTITY bcia                    "&suselinux; BCI">


### PR DESCRIPTION
### PR creator: Description

Rebrand the *SLE Base Container Images* / *SLE BCI* product name to
*SUSE Linux Base Container Images* / *SUSE Linux BCI* throughout the
Container Guide.

The rename is **entity-only**: every occurrence in the prose is already
written via the `&bci;` / `&bcia;` (acronym) entities, so this PR ships
a single override file (`container-guide/common/product-entities.ent`)
that redefines those two entities. The entity name itself is unchanged,
so every `&bci;` / `&bcia;` reference in the chapters keeps working and
no chapter file is touched by this PR.

The new wording matches the current SUSE marketing for the product
(SUSE Linux line) and is consistent with the rebrand the registry
README and product pages have already adopted.

### PR creator: Are there any relevant issues/feature requests?

None — community contribution. Happy to add a `bsc#`/`jsc#` reference
if the doc team has one tracking the rebrand.