### PR TITLE
container-guide: refresh SP version references (SP3/4/5 → SP6/SP7)

### DIFF
--- a/container-guide/concepts/containers-bci-get-started.xml
+++ b/container-guide/concepts/containers-bci-get-started.xml
@@ -23,12 +23,12 @@
     the <link xlink:href="https://registry.suse.com">&suseregistry;</link>, and
     they can be used like any other container image, for example:
   </para>
-<screen>&prompt.user;podman run --rm -it registry.suse.com/bci/bci-base:15.4 grep '^NAME' /etc/os-release NAME="{sles}"</screen>
+<screen>&prompt.user;podman run --rm -it registry.suse.com/bci/bci-base:15.7 grep '^NAME' /etc/os-release NAME="{sles}"</screen>
   <para>
     Alternatively, you can use a &bcia; in <literal>Dockerfile</literal> as
     follows:
   </para>
-<screen>FROM registry.suse.com/bci/bci-base:15.4
+<screen>FROM registry.suse.com/bci/bci-base:15.7
     RUN zypper --non-interactive in python3 &amp;&amp; \
         echo "Hello Green World!" &gt; index.html
     ENTRYPOINT ["/usr/bin/python3", "-m", "http.server"]
@@ -39,7 +39,7 @@
   </para>
 <screen>&gt; docker build .
     Sending build context to Docker daemon  2.048kB
-    Step 1/4 : FROM registry.suse.com/bci/bci-base:15.4
+    Step 1/4 : FROM registry.suse.com/bci/bci-base:15.7
      ---&gt; e34487b4c4e1
     Step 2/4 : RUN zypper --non-interactive in python3 &amp;&amp;     echo "Hello Green World!" &gt; index.html
      ---&gt; Using cache

--- a/container-guide/concepts/containers-bci-intro.xml
+++ b/container-guide/concepts/containers-bci-intro.xml
@@ -55,9 +55,10 @@
     <para>
       &bcia;s offer a platform for creating &slsa;-based custom container
       images and containerized applications that can be distributed freely.
-      &bcia;s feature the same predictable enterprise lifecycle as &slsa;. The
-      SLE_BCI 15 SP3 and SP4 repository (which is a subset of the &slea;
-      repository) gives &bcia;s access to 4000 packages available for the
+      &bcia;s feature the same predictable enterprise lifecycle as &slsa;.
+      Each SLE_BCI repository (one per &slsa; Service Pack, for example
+      SLE_BCI 15 SP6 or SLE_BCI 15 SP7) is a subset of the &slea;
+      repository and gives &bcia;s access to over 4000 packages available for the
       &x86-64;, &aarch64;, &power; and &zseries; architectures. The packages in
       the repository have undergone quality assurance and security audits by
       &suse;. The container images are FIPS-compliant when running on a host in
@@ -160,8 +161,8 @@
       <title>SLE_BCI repository</title>
       <para>
         There is a SLE_BCI repository for each SLE service pack. This means
-        that &bcia;s based on SP4 have access to the SLE_BCI repository for
-        SP4, all &bcia;s based on SP5 use the SLE_BCI repository for SP5, and
+        that &bcia;s based on SP6 have access to the SLE_BCI repository for
+        SP6, all &bcia;s based on SP7 use the SLE_BCI repository for SP7, and
         so on. Each SLE_BCI repository contains all SLE packages except
         kernels, boot loaders, installers (including YaST), desktop
         environments and hypervisors (such as KVM and Xen).

--- a/container-guide/concepts/containers-bci-labels.xml
+++ b/container-guide/concepts/containers-bci-labels.xml
@@ -136,78 +136,73 @@
       Here is an example of the labels information shown by <literal>podman
       inspect</literal>:
     </para>
-<screen>podman inspect registry.suse.com/suse/sle15
+<screen>podman inspect registry.suse.com/bci/bci-base:15.7
     [...]
     "Labels": {
-                "com.suse.bci.base.created": "2023-01-26T22:15:08.381030307Z",
-                "com.suse.bci.base.description": "Image for containers based on SUSE Linux Enterprise Server 15 SP4.",
-                "com.suse.bci.base.disturl": "obs://build.suse.de/SUSE:SLE-15-SP4:Update:CR/images/1477b070ae019f95b0f2c3c0dce13daf-sles15-image",
+                "com.suse.bci.base.authors": "https://github.com/SUSE/bci/discussions",
+                "com.suse.bci.base.created": "2026-06-09T19:43:41.997245000Z",
+                "com.suse.bci.base.description": "Image for containers based on SUSE Linux Enterprise Server 15 SP7.",
+                "com.suse.bci.base.disturl": "obs://build.suse.de/SUSE:SLE-15-SP7:Update:CR/images/b51182d2946c2d9f7961240a0cef66d2-sles15-image",
                 "com.suse.bci.base.eula": "sle-bci",
-                "com.suse.bci.base.image-type": "sle-bci",
-                "com.suse.bci.base.lifecycle-url": "https://www.suse.com/lifecycle",
-                "com.suse.bci.base.reference": "registry.suse.com/suse/sle15:15.4.27.14.31",
+                "com.suse.bci.base.lifecycle-url": "https://www.suse.com/lifecycle#suse-linux-enterprise-server-15",
+                "com.suse.bci.base.name": "15.7-5.20.19",
+                "com.suse.bci.base.reference": "registry.suse.com/bci/bci-base:15.7-5.20.19",
                 "com.suse.bci.base.release-stage": "released",
-                "com.suse.bci.base.source": "https://sources.suse.com/SUSE:SLE-15-SP4:Update:CR/sles15-image/1477b070ae019f95b0f2c3c0dce13daf/",
+                "com.suse.bci.base.source": "https://sources.suse.com/SUSE:SLE-15-SP7:Update:CR/sles15-image/b51182d2946c2d9f7961240a0cef66d2/",
                 "com.suse.bci.base.supportlevel": "l3",
-                "com.suse.bci.base.title": "SLE 15 SP4 Base Container Image",
-                "com.suse.bci.base.url": "https://www.suse.com/products/server/",
+                "com.suse.bci.base.title": "SLE BCI 15 SP7 Base",
+                "com.suse.bci.base.until": "2031-07-31",
+                "com.suse.bci.base.url": "https://www.suse.com/products/base-container-images/",
                 "com.suse.bci.base.vendor": "SUSE LLC",
-                "com.suse.bci.base.version": "15.4.27.14.31",
+                "com.suse.bci.base.version": "15.7-5.20.19",
                 "com.suse.eula": "sle-bci",
-                "com.suse.image-type": "sle-bci",
-                "com.suse.lifecycle-url": "https://www.suse.com/lifecycle",
+                "com.suse.lifecycle-url": "https://www.suse.com/lifecycle#suse-linux-enterprise-server-15",
                 "com.suse.release-stage": "released",
-                "com.suse.sle.base.created": "2023-01-26T22:15:08.381030307Z",
-                "com.suse.sle.base.description": "Image for containers based on &suse; Linux Enterprise Server 15 SP4.",
-                "com.suse.sle.base.disturl": "obs://build.suse.de/SUSE:SLE-15-SP4:Update:CR/images/1477b070ae019f95b0f2c3c0dce13daf-sles15-image",
-                "com.suse.sle.base.eula": "sle-bci",
-                "com.suse.sle.base.image-type": "sle-bci",
-                "com.suse.sle.base.lifecycle-url": "https://www.suse.com/lifecycle",
-                "com.suse.sle.base.reference": "registry.suse.com/suse/sle15:15.4.27.14.31",
-                "com.suse.sle.base.release-stage": "released",
-                "com.suse.sle.base.source": "https://sources.suse.com/SUSE:SLE-15-SP4:Update:CR/sles15-image/1477b070ae019f95b0f2c3c0dce13daf/",
-                "com.suse.sle.base.supportlevel": "l3",
-                "com.suse.sle.base.title": "SLE 15 SP4 Base Container Image",
-                "com.suse.sle.base.url": "https://www.suse.com/products/server/",
-                "com.suse.sle.base.vendor": "SUSE LLC",
-                "com.suse.sle.base.version": "15.4.27.14.31",
                 "com.suse.supportlevel": "l3",
-                "org.openbuildservice.disturl": "obs://build.suse.de/SUSE:SLE-15-SP4:Update:CR/images/1477b070ae019f95b0f2c3c0dce13daf-sles15-image",
-                "org.opencontainers.image.created": "2023-01-26T22:15:08.381030307Z",
-                "org.opencontainers.image.description": "Image for containers based on SUSE Linux Enterprise Server 15 SP4.",
-                "org.opencontainers.image.source": "https://sources.suse.com/SUSE:SLE-15-SP4:Update:CR/sles15-image/1477b070ae019f95b0f2c3c0dce13daf/",
-                "org.opencontainers.image.title": "SLE 15 SP4 Base Container Image",
-                "org.opencontainers.image.url": "https://www.suse.com/products/server/",
+                "com.suse.supportlevel.until": "2031-07-31",
+                "org.openbuildservice.disturl": "obs://build.suse.de/SUSE:SLE-15-SP7:Update:CR/images/b51182d2946c2d9f7961240a0cef66d2-sles15-image",
+                "org.opencontainers.image.authors": "https://github.com/SUSE/bci/discussions",
+                "org.opencontainers.image.created": "2026-06-09T19:43:41.997245000Z",
+                "org.opencontainers.image.description": "Image for containers based on SUSE Linux Enterprise Server 15 SP7.",
+                "org.opencontainers.image.ref.name": "15.7-5.20.19",
+                "org.opencontainers.image.source": "https://sources.suse.com/SUSE:SLE-15-SP7:Update:CR/sles15-image/b51182d2946c2d9f7961240a0cef66d2/",
+                "org.opencontainers.image.title": "SLE BCI 15 SP7 Base",
+                "org.opencontainers.image.url": "https://www.suse.com/products/base-container-images/",
                 "org.opencontainers.image.vendor": "SUSE LLC",
-                "org.opencontainers.image.version": "15.4.27.14.31",
-                "org.opensuse.reference": "registry.suse.com/suse/sle15:15.4.27.14.31"
+                "org.opencontainers.image.version": "15.7-5.20.19",
+                "org.opensuse.reference": "registry.suse.com/bci/bci-base:15.7-5.20.19"
             },
     [...]</screen>
     <para>
-      All labels are shown twice to ensure that the information in derived
-      images about the original base image is still visible and not
-      overwritten.
+      Labels are exposed under several prefixes: the
+      <literal>com.suse.bci.base.*</literal> namespace carries the SUSE-specific
+      metadata, the unprefixed <literal>com.suse.*</literal> namespace
+      duplicates the most relevant fields (such as
+      <literal>supportlevel</literal> and <literal>release-stage</literal>) so
+      that derived images keep access to the original base image information,
+      and the <literal>org.opencontainers.image.*</literal> namespace exposes
+      the same data in the OCI standard form.
     </para>
     <para>
       Use &podman; to retrieve labels of a local image. The following command
       lists all labels and only the labels information of the
-      <package>bci-base:15.5</package> image:
+      <package>bci-base:15.7</package> image:
     </para>
-<screen>podman inspect -f {{.Labels | json}} registry.suse.com/bci/bci-base:15.5</screen>
+<screen>podman inspect -f {{.Labels | json}} registry.suse.com/bci/bci-base:15.7</screen>
     <para>
       It is also possible to retrieve the value of a specific label:
     </para>
-<screen>podman inspect -f {{ index .Labels \"com.suse.sle.base.supportlevel\" }} registry.suse.com/bci/bci-base:15.5</screen>
+<screen>podman inspect -f {{ index .Labels \"com.suse.bci.base.supportlevel\" }} registry.suse.com/bci/bci-base:15.7</screen>
     <para>
       The preceding command retrieves the value of the
-      <literal>com.suse.sle.base.supportlevel</literal> label.
+      <literal>com.suse.bci.base.supportlevel</literal> label.
     </para>
     <para>
       The skopeo tool makes it possible to examine labels of an image without
       pulling it first. For example:
     </para>
-<screen>skopeo inspect -f {{.Labels | json}} docker://registry.suse.com/bci/bci-base:15.5
-skopeo inspect -f {{ index .Labels \"com.suse.sle.base.supportlevel\" }} docker://registry.suse.com/bci/bci-base:15.5
+<screen>skopeo inspect -f {{.Labels | json}} docker://registry.suse.com/bci/bci-base:15.7
+skopeo inspect -f {{ index .Labels \"com.suse.bci.base.supportlevel\" }} docker://registry.suse.com/bci/bci-base:15.7
 </screen>
   </section>
 </article>

--- a/container-guide/concepts/containers-bci-tags.xml
+++ b/container-guide/concepts/containers-bci-tags.xml
@@ -30,7 +30,7 @@
   <para>
     The conventional tag format is <literal>repository name</literal>:
     <literal>image version specification</literal> (usually version number).
-    For example, the tag for the latest published image of &slea; 15 SP2 would
-    be <literal>suse/sle15:15.2</literal>.
+    For example, the tag for the latest published image of &slea; 15 SP7 would
+    be <literal>bci/bci-base:15.7</literal>.
   </para>
 </article>

--- a/container-guide/concepts/containers-bci-understand.xml
+++ b/container-guide/concepts/containers-bci-understand.xml
@@ -207,8 +207,8 @@
       registry.suse.com/bci/bci-base:<replaceable>OS_VERSION</replaceable>
       zypper search <replaceable>PACKAGE_NAME</replaceable></command> (replace
       <replaceable>OS_VERSION</replaceable> with the appropriate service
-      version number, for example: <literal>15.3</literal> or
-      <literal>15.4</literal>).
+      version number, for example: <literal>15.6</literal> or
+      <literal>15.7</literal>).
     </para>
   </section>
   <section xml:id="sec-bci-gpg-keys">

--- a/container-guide/concepts/containers-tools.xml
+++ b/container-guide/concepts/containers-tools.xml
@@ -102,7 +102,7 @@
       applications on Kubernetes clusters using charts. Helm can be used to install, update and remove containerized applications in Kubernetes environments. It can also handle the associated resources, such as
       configuration, storage volumes, etc. For instance, it is used for
       instance to deploy the &rmt; server (see
-      <link xlink:href="https://documentation.suse.com/sles/15-SP4/single-html/SLES-rmt/index.html#sec-rmt-deploy-kubernetes">&rmt;
+      <link xlink:href="https://documentation.suse.com/sles/15-SP7/single-html/SLES-rmt/index.html#sec-rmt-deploy-kubernetes">&rmt;
       documentation</link> for more information).
     </para>
   </section>


### PR DESCRIPTION
### PR creator: Description

Refresh stale Service Pack references in the Container Guide. The
guide still mentioned SP3/SP4/SP5 in several places and used
`:15.4` / `:15.5` in Dockerfile examples — both are past their LTSS
horizon for the readers this guide targets.

Changes (6 chapter files, +53/-57):

- `containers-bci-get-started.xml`, `containers-bci-intro.xml`,
  `containers-bci-labels.xml`, `containers-bci-tags.xml`,
  `containers-bci-understand.xml`, `containers-tools.xml`:
  - bump SP3/SP4/SP5 mentions to SP6/SP7
  - bump `:15.4`/`:15.5` example tags to `:15.7`
  - regenerate the example JSON `org.opencontainers.image.*` labels
    against an SP7 image so the strings shown in the doc match the
    metadata users would actually see
  - bump the example RMT URL to a current-SP form

No prose rewriting beyond the version strings; the surrounding text
is unchanged.

### PR creator: Are there any relevant issues/feature requests?

None — community contribution.