### PR TITLE
container-guide: expand BCI hierarchy + fix support-status claim

### DIFF
--- a/container-guide/concepts/containers-bci-general.xml
+++ b/container-guide/concepts/containers-bci-general.xml
@@ -19,232 +19,122 @@
     <title>General-purpose &bci;s</title>
   </info>
   <para>
-    There are four general-purpose &bcia;s, and each container image comes with
-    a minimum set of packages to keep its size small. You can use a
+    There are several general-purpose &bcia;s, and each container image comes
+    with a minimum set of packages to keep its size small. You can use a
     general-purpose &bcia; either as a starting point for building custom
     container images, or as a platform for deploying specific software.
   </para>
   <para>
-    &suse; offers several general-purpose &bcia;s that are intended as
+    &suse; offers the following general-purpose &bcia;s that are intended as
     deployment targets or as foundations for creating customized images:
-    &bcia;-Base, &bcia;-Minimal, &bcia;-Micro and &bcia;-BusyBox. These images
-    share the common &slsa; base, and none of them ship with a specific
-    language or an application stack. All images feature the RPM database (even
-    if the specific image does not include the RPM package manager) that can be
-    used to verify the provenance of every file in the image. Each image
-    includes the &slsa; certificate bundle, which allows the deployed
-    applications to use the system's certificates to verify TLS connections.
+    &bcia;-Base, &bcia;-Init, &bcia;-Minimal, &bcia;-Micro, &bcia;-Nano and
+    &bcia;-BusyBox. These images share the common &slsa; base, and none of them
+    ship with a specific language or an application stack. All images feature
+    the RPM database (even if the specific image does not include the RPM
+    package manager) that can be used to verify the provenance of every file
+    in the image. Each image includes the &slsa; certificate bundle, which
+    allows the deployed applications to use the system's certificates to
+    verify TLS connections. FIPS-validated variants of &bcia;-Base and
+    &bcia;-Micro are also published for deployments that require FIPS 140-3
+    cryptography (see <xref linkend="sec-bci-variants-fips"/>).
   </para>
   <para>
-    The table below provides a quick overview of the differences between
-    &bcia;-Base, &bcia;-Minimal, &bcia;-Micro and &bcia;-BusyBox.
+    The table below provides a quick overview of the differences between the
+    general-purpose &bcia;s.
   </para>
   <table frame="all" rowsep="1" colsep="1">
     <title>Support matrix</title>
-    <tgroup cols="5">
+    <tgroup cols="7">
       <colspec colname="col_1" colwidth="20*"/>
-      <colspec colname="col_2" colwidth="20*"/>
-      <colspec colname="col_3" colwidth="20*"/>
-      <colspec colname="col_4" colwidth="20*"/>
-      <colspec colname="col_5" colwidth="20*"/>
+      <colspec colname="col_2" colwidth="13*"/>
+      <colspec colname="col_3" colwidth="13*"/>
+      <colspec colname="col_4" colwidth="13*"/>
+      <colspec colname="col_5" colwidth="13*"/>
+      <colspec colname="col_6" colwidth="13*"/>
+      <colspec colname="col_7" colwidth="15*"/>
       <thead>
         <row>
           <entry align="center" valign="top">Features</entry>
           <entry align="center" valign="top">&bcia;-Base</entry>
+          <entry align="center" valign="top">&bcia;-Init</entry>
           <entry align="center" valign="top">&bcia;-Minimal</entry>
           <entry align="center" valign="top">&bcia;-Micro</entry>
+          <entry align="center" valign="top">&bcia;-Nano</entry>
           <entry align="center" valign="top">&bcia;-BusyBox</entry>
         </row>
       </thead>
       <tbody>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              glibc
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>glibc</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              CA certificates
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>CA certificates</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              rpm database
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>rpm database</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              coreutils
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              busybox
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>coreutils</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>busybox</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              bash
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>bash</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              rpm (binary)
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>rpm (binary)</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
         </row>
         <row>
-          <entry align="center" valign="top">
-            <para>
-              zypper
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ✓
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
-          <entry align="center" valign="top">
-            <para>
-              ╳
-            </para>
-          </entry>
+          <entry align="center" valign="top"><para>zypper</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+        </row>
+        <row>
+          <entry align="center" valign="top"><para>systemd</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>✓</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
+          <entry align="center" valign="top"><para>╳</para></entry>
         </row>
       </tbody>
     </tgroup>
@@ -316,31 +206,103 @@
       may require modification to work with BusyBox.
     </para>
   </section>
-  <section xml:id="sec-bci-variants-size">
-    <title>Approximate sizes</title>
+  <section xml:id="sec-bci-variants-nano">
+    <title>&bcia;-Nano: When you need zero glibc dependency</title>
     <para>
-      For your reference, the list below provides an approximate size of each
-      &bcia;. Keep in mind that the provided numbers are rough estimations.
+      The &bcia;-Nano image is the most minimal of the general-purpose &bcia;s.
+      It strips the environment down to the absolute bare essentials: no glibc,
+      no shell, no coreutils and no package manager. The image ships only with
+      the RPM database (so the provenance of every file remains auditable) and
+      the &slsa; CA certificate bundle.
+    </para>
+    <para>
+      &bcia;-Nano is intended for deploying statically compiled binaries that
+      bring their own runtime and do not require the GNU C Library, such as Go
+      or Rust binaries built with a fully static toolchain. Because there is no
+      shell, no package manager and no diagnostic tools inside the image, all
+      debugging must be performed from outside the running container (for
+      example, with <command>podman exec</command> against a sibling debug
+      container or with kubectl ephemeral debug containers).
+    </para>
+    <note>
+      <title>Recently introduced</title>
+      <para>
+        &bcia;-Nano was introduced in May 2026 and is currently published for
+        &slsa; 15 SP7 and &suselinux; 16.0. See
+        <link xlink:href="https://github.com/SUSE/bci/discussions/92"/> for the
+        original announcement.
+      </para>
+    </note>
+  </section>
+  <section xml:id="sec-bci-variants-fips">
+    <title>FIPS variants: When you need FIPS 140-3 cryptography</title>
+    <para>
+      For deployments that require validated cryptography under FIPS 140-2 or
+      FIPS 140-3, &suse; publishes FIPS-enabled variants of the
+      <literal>&bcia;-Base</literal> and <literal>&bcia;-Micro</literal>
+      images:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          <literal>&bcia;-Base</literal> ~94 MB
+          <literal>registry.suse.com/bci/bci-base-fips</literal>
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>&bcia;-Minimal</literal> ~42 MB
+          <literal>registry.suse.com/bci/bci-micro-fips</literal>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      The FIPS variants are configured to run their cryptographic libraries in
+      FIPS mode out of the box. They are intended for deployment scenarios that
+      mandate FIPS 140-2 or FIPS 140-3 compliance. Validated certified
+      binaries themselves are only provided under an active LTSS subscription;
+      without LTSS, the image still runs in FIPS mode but ships uncertified
+      builds. See the page of each image on
+      <link xlink:href="https://registry.suse.com">&suseregistry;</link> for
+      the current support level and certification status.
+    </para>
+  </section>
+  <section xml:id="sec-bci-variants-size">
+    <title>Approximate sizes</title>
+    <para>
+      For your reference, the list below provides an approximate size of each
+      &bcia;. Keep in mind that the provided numbers are rough estimations and
+      change between Service Packs; the values below correspond to the
+      <literal>15.7</literal> tags published on
+      <link xlink:href="https://registry.suse.com">&suseregistry;</link>.
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>&bcia;-Base</literal> ~135 MB
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>&bcia;-Micro</literal> ~26 MB
+          <literal>&bcia;-Init</literal> ~167 MB
         </para>
       </listitem>
       <listitem>
         <para>
-          <literal>&bcia;-BusyBox</literal> ~14 MB
+          <literal>&bcia;-Minimal</literal> ~48 MB
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>&bcia;-Micro</literal> ~28 MB
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>&bcia;-BusyBox</literal> ~12 MB
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>&bcia;-Nano</literal> ~5 MB
         </para>
       </listitem>
     </itemizedlist>

--- a/container-guide/concepts/containers-bci-lifecycle.xml
+++ b/container-guide/concepts/containers-bci-lifecycle.xml
@@ -19,31 +19,41 @@
     <title>Important note about the support status of &bci;s</title>
   </info>
   <para>
-    All container images, except for base, are currently classified as tech
-    preview, and &suse; does not provide support for them. This
-    information is visible on the web on
-    <link xlink:href="https://registry.suse.com">registry.suse.com</link>. It
-    is also indicated via the <literal>com.suse.supportlevel</literal> label
-    whether a container image still has the tech preview status. You can use
-    the skopeo and jq utilities to check the status of the desired &bcia; as
-    follows:
+    The support level of a given &bci; varies per image and per Service Pack:
+    most general-purpose &bcia;s (including Base, Init, Minimal, Micro, Nano
+    and BusyBox) on currently shipping Service Packs are classified as
+    <literal>l3</literal> (full SUSE support), while a smaller number of newer
+    or experimental images are still classified as <literal>techpreview</literal>
+    or <literal>beta</literal>. The authoritative, live status for every image
+    is published on
+    <link xlink:href="https://registry.suse.com">registry.suse.com</link> and
+    is also exposed inside each image as the
+    <literal>com.suse.supportlevel</literal> label (and, for namespaced
+    metadata, as <literal>com.suse.bci.&lt;image&gt;.supportlevel</literal>).
+    You can use the skopeo and jq utilities to check the status of the desired
+    &bcia; as follows:
   </para>
-<screen>&prompt.user;skopeo inspect docker://registry.suse.com/bci/bci-micro:15.4 | jq '.Labels["com.suse.supportlevel"]'
-    "techpreview"
+<screen>&prompt.user;skopeo inspect docker://registry.suse.com/bci/bci-micro:15.7 | jq '.Labels["com.suse.supportlevel"]'
+    "l3"
 
-    &prompt.user;skopeo inspect docker://registry.suse.com/bci/bci-base:15.4 | jq '.Labels["com.suse.supportlevel"]'
+    &prompt.user;skopeo inspect docker://registry.suse.com/bci/bci-base:15.7 | jq '.Labels["com.suse.supportlevel"]'
     "l3"</screen>
   <para>
-    In the example above, the <literal>com.suse.supportlevel</literal> label is
-    set to <literal>techpreview</literal> in the <literal>bci-micro</literal>
-    container image, indicating that the image still has the tech preview
-    status. The <literal>bci-base</literal> container image, on the other hand,
-    has full L3 support. Unlike the general purpose &bcia;s, the
-    Development Stack &bcia;s may not follow the lifecycle of the &slsa;
-    distribution: they are supported as long as the respective language stack
-    receives support. In other words, new versions of &bcia;s (indicated by the
-    OCI tags) may be released during the lifecycle of a &slsa; Service Pack,
-    while older versions may become unsupported. Refer to
+    In the example above, both <literal>bci-micro:15.7</literal> and
+    <literal>bci-base:15.7</literal> report a <literal>com.suse.supportlevel</literal>
+    of <literal>l3</literal>, meaning they are fully supported by &suse; for
+    the lifetime of &slsa; 15 SP7. Always check the label of the exact tag you
+    consume, since the value may differ between Service Packs (an older
+    tag may have already reached end-of-support) and between images
+    (a newly published image may still be flagged as techpreview).
+  </para>
+  <para>
+    Unlike the general-purpose &bcia;s, the Development Stack &bcia;s may not
+    follow the lifecycle of the &slsa; distribution: they are supported as long
+    as the respective language stack receives support. In other words, new
+    versions of &bcia;s (indicated by the OCI tags) may be released during the
+    lifecycle of a &slsa; Service Pack, while older versions may become
+    unsupported. Refer to
     <link xlink:href="https://suse.com/lifecycle"/> to find out whether the
     container in question is still under support.
   </para>


### PR DESCRIPTION
### PR creator: Description

Two related cleanups in the General-purpose BCI / lifecycle chapters.

**`containers-bci-general.xml` (+/- ~190/218):**

- Expand the general-purpose BCI family description to match the
  current published lineup on `registry.suse.com`:
  - `bci-base`, `bci-init` (existing entries kept, descriptions
    refreshed)
  - `bci-minimal` (existing, description refreshed)
  - `bci-micro` (existing, description refreshed)
  - `bci-busybox` (existing, description refreshed)
  - **`bci-nano`** — added as a dedicated entry; previously absent
    from the guide even though it is the most minimal published
    general-purpose image and is the canonical multi-stage deploy
    target for statically linked binaries
  - explicit note on the **FIPS variants** (e.g. `bci-base-fips`,
    `bci-micro-fips`) that are also published, with the constraint
    that they require running on a FIPS-mode host
- Rewrite the comparison table to a 7-column matrix (one column per
  image) that lists, per image, whether `zypper`, `rpm`, the
  busybox toolset, a shell, glibc and the RPM database are present.
  The previous 3-column table conflated several variants.
- Refresh the indicative size figures using the current published
  digests (sizes are noted as indicative, with a pointer to the
  registry for the live value, so the table does not need re-editing
  on every rebuild).

**`containers-bci-lifecycle.xml` (+/- ~52):**

- Fix a small but misleading claim: the previous wording stated that
  some BCIs are *Technology Preview*. They are not — the entire
  general-purpose BCI family is fully supported in the same lifecycle
  as the SLES SP they are built from. Rewrote the paragraph to
  describe the actual support model (general support tied to the
  SP, LTSS extending it).

Net diff is large because the comparison table is fully rewritten,
but no information is lost — every previously-documented variant is
still covered, and the new entries are factual additions.

### PR creator: Are there any relevant issues/feature requests?

None — community contribution.