### PR TITLE
container-guide: drop Notary v1, fix key URL typo, flag :latest migration

### DIFF
--- a/container-guide/concepts/containers-bci-intro.xml
+++ b/container-guide/concepts/containers-bci-intro.xml
@@ -75,8 +75,10 @@
             vulnerabilities are announced via e-mail, the dedicated
             <link xlink:href="https://www.suse.com/security/cve/">CVE
             pages</link>, and as OVAL and CVRF data. To ensure a secure supply
-            chain, all container images are signed with Notary v1, &podman;'s GPG
-            signatures, and Sigstore Cosign.
+            chain, all container images are signed with Sigstore Cosign and
+            &podman;'s GPG signatures. Notary v1 / Docker Content Trust is no
+            longer used; its deprecation on <literal>registry.suse.com</literal>
+            was announced in February 2026.
           </para>
         </listitem>
       </varlistentry>

--- a/container-guide/concepts/containers-bci-tags.xml
+++ b/container-guide/concepts/containers-bci-tags.xml
@@ -34,30 +34,42 @@
     be <literal>suse/sle15:15.2</literal>.
   </para>
   <important>
-    <title>The <literal>latest</literal> tag now points to &suselinux; 16</title>
+    <title>The <literal>latest</literal> tag is migrating to &suselinux; 16</title>
     <para>
-      Since 15 January 2026, the <literal>latest</literal> tag for the
-      core-infrastructure &bcia;s (<literal>bci-base</literal>,
-      <literal>bci-init</literal>, <literal>bci-minimal</literal>,
-      <literal>bci-micro</literal>, <literal>bci-busybox</literal>) points to
-      &suselinux; 16, not to &slsa; 15. Pulling
-      <literal>registry.suse.com/bci/bci-base:latest</literal> today therefore
-      gives you a 16.0-based image.
+      The base of the &bcia; family is migrating from &slsa; 15 to
+      &suselinux; 16. The migration is staged image by image, not flipped at
+      once: <literal>bci-nano</literal> is the first general-purpose image
+      to move, and the core-infrastructure images
+      (<literal>bci-base</literal>, <literal>bci-init</literal>,
+      <literal>bci-minimal</literal>, <literal>bci-micro</literal>,
+      <literal>bci-busybox</literal>) will follow at a later date that is
+      pre-announced on the SUSE blog and on the
+      <link xlink:href="https://github.com/SUSE/bci/discussions">SUSE/bci
+      discussions board</link>. Until that flip happens, pulling
+      <literal>registry.suse.com/bci/bci-base:latest</literal> still gives
+      you a 15 SP7-based image; check the live registry page or
+      <command>cat /etc/os-release</command> in the image to confirm the
+      current target of <literal>:latest</literal> for any given image.
     </para>
     <para>
-      If you want to stay on &slsa; 15, always pin to an explicit version
-      tag (for example <literal>15.7</literal>) in your <literal>FROM</literal>
-      lines, in your CI pipelines and in any <literal>podman pull</literal>
-      command. &slsa; 15 SP7 &bcia;s remain maintained until the end of general
-      support for SP7 (31 July 2031). For SP6 and earlier, refer to
-      <link xlink:href="https://www.suse.com/lifecycle"/>.
+      Regardless of the current target, do not rely on
+      <literal>:latest</literal> for reproducible builds. Always pin to an
+      explicit version tag (for example <literal>15.7</literal> for &slsa;
+      15 SP7, or the relevant <literal>16.x</literal> tag for &suselinux;
+      16) in your <literal>FROM</literal> lines, in your CI pipelines and
+      in any <literal>podman pull</literal> command, so that a future
+      <literal>:latest</literal> pivot does not silently change the base of
+      your deployment. &slsa; 15 SP7 &bcia;s remain maintained until the
+      end of general support for SP7 (31 July 2031). For SP6 and earlier,
+      refer to <link xlink:href="https://www.suse.com/lifecycle"/>.
     </para>
     <para>
       See
       <link xlink:href="https://www.suse.com/c/suse-linux-base-container-images-latest-tag-moving-to-sles-16/"/>
       and
       <link xlink:href="https://github.com/SUSE/bci/discussions/60"/>
-      for the original announcement.
+      for the original announcement and the up-to-date status of the
+      per-image flips.
     </para>
   </important>
 </article>

--- a/container-guide/concepts/containers-bci-tags.xml
+++ b/container-guide/concepts/containers-bci-tags.xml
@@ -37,17 +37,18 @@
     <title>The <literal>latest</literal> tag is migrating to &suselinux; 16</title>
     <para>
       The base of the &bcia; family is migrating from &slsa; 15 to
-      &suselinux; 16. The migration is staged image by image, not flipped at
-      once: <literal>bci-nano</literal> is the first general-purpose image
-      to move, and the core-infrastructure images
+      &suselinux; 16. The migration is staged image by image, not flipped
+      at once: <literal>bci-nano</literal> is the first general-purpose
+      image to move, and the core-infrastructure images
       (<literal>bci-base</literal>, <literal>bci-init</literal>,
       <literal>bci-minimal</literal>, <literal>bci-micro</literal>,
-      <literal>bci-busybox</literal>) will follow at a later date that is
-      pre-announced on the SUSE blog and on the
+      <literal>bci-busybox</literal>) will follow later. SUSE will
+      communicate the timing of each flip through the usual channels (the
+      SUSE blog and the
       <link xlink:href="https://github.com/SUSE/bci/discussions">SUSE/bci
-      discussions board</link>. Until that flip happens, pulling
+      discussions board</link>); until each flip happens, pulling
       <literal>registry.suse.com/bci/bci-base:latest</literal> still gives
-      you a 15 SP7-based image; check the live registry page or
+      you a 15 SP7-based image. Check the live registry page or
       <command>cat /etc/os-release</command> in the image to confirm the
       current target of <literal>:latest</literal> for any given image.
     </para>

--- a/container-guide/concepts/containers-bci-tags.xml
+++ b/container-guide/concepts/containers-bci-tags.xml
@@ -33,4 +33,31 @@
     For example, the tag for the latest published image of &slea; 15 SP2 would
     be <literal>suse/sle15:15.2</literal>.
   </para>
+  <important>
+    <title>The <literal>latest</literal> tag now points to &suselinux; 16</title>
+    <para>
+      Since 15 January 2026, the <literal>latest</literal> tag for the
+      core-infrastructure &bcia;s (<literal>bci-base</literal>,
+      <literal>bci-init</literal>, <literal>bci-minimal</literal>,
+      <literal>bci-micro</literal>, <literal>bci-busybox</literal>) points to
+      &suselinux; 16, not to &slsa; 15. Pulling
+      <literal>registry.suse.com/bci/bci-base:latest</literal> today therefore
+      gives you a 16.0-based image.
+    </para>
+    <para>
+      If you want to stay on &slsa; 15, always pin to an explicit version
+      tag (for example <literal>15.7</literal>) in your <literal>FROM</literal>
+      lines, in your CI pipelines and in any <literal>podman pull</literal>
+      command. &slsa; 15 SP7 &bcia;s remain maintained until the end of general
+      support for SP7 (31 July 2031). For SP6 and earlier, refer to
+      <link xlink:href="https://www.suse.com/lifecycle"/>.
+    </para>
+    <para>
+      See
+      <link xlink:href="https://www.suse.com/c/suse-linux-base-container-images-latest-tag-moving-to-sles-16/"/>
+      and
+      <link xlink:href="https://github.com/SUSE/bci/discussions/60"/>
+      for the original announcement.
+    </para>
+  </important>
 </article>

--- a/container-guide/concepts/containers-verify.xml
+++ b/container-guide/concepts/containers-verify.xml
@@ -176,7 +176,7 @@
         <link xlink:href="https://www.suse.com/support/security/keys/">&suse;
         Signing Keys</link>, or use the following command:
       </para>
-<screen linenumbering="unnumbered">&gt; sudo curl -s https://ftp.suse.com/pub/projects/security/keys/container–key.pem \
+<screen linenumbering="unnumbered">&gt; sudo curl -s https://ftp.suse.com/pub/projects/security/keys/container-key.pem \
         -o /usr/share/pki/containers/suse-container-key.pem</screen>
       <note>
         <para>


### PR DESCRIPTION
### PR creator: Description

Three security-chapter cleanups, plus a note on the upcoming `:latest`
migration to SUSE Linux 16.

**`containers-bci-intro.xml`:**

- The "supply chain" paragraph still listed *Notary v1* as one of the
  signing mechanisms in active use. Notary v1 / Docker Content Trust
  was deprecated and removed from `registry.suse.com`; the active
  mechanisms are Sigstore Cosign and Podman's GPG signatures.
  Reworded accordingly.

**`containers-verify.xml`:**

- Fix an en-dash typo in the example `curl` URL for the SUSE
  container signing key. The published URL uses an ASCII hyphen
  (`container-key.pem`); the doc had `container–key.pem` (U+2013),
  which makes the example fail when copy-pasted.

**`containers-bci-tags.xml`:**

- Add an `<important>` note about the `:latest` tag migrating to
  SUSE Linux 16. The migration is **staged image by image**: only
  `bci-nano` has moved so far; the core-infrastructure images
  (`bci-base`, `bci-init`, `bci-minimal`, `bci-micro`,
  `bci-busybox`) will follow later. The note does not promise a
  specific flip date — it points readers at the SUSE blog and the
  [SUSE/bci discussions board](https://github.com/SUSE/bci/discussions)
  for the timing, and recommends pinning explicit version tags
  (`15.7` for SLES 15 SP7, the relevant `16.x` for SUSE Linux 16)
  rather than relying on `:latest`. Includes a one-line hint
  (`cat /etc/os-release` inside the image) for readers who want to
  verify the current target of `:latest` themselves.

### PR creator: Are there any relevant issues/feature requests?

None — community contribution.

Refs:
- https://github.com/SUSE/bci/discussions/60 — upcoming `:latest`
  tag change for redistributable base-OS containers