### PR TITLE
container-guide: refresh language stacks and expand application BCIs

### DIFF
--- a/container-guide/concepts/containers-bci-app.xml
+++ b/container-guide/concepts/containers-bci-app.xml
@@ -19,10 +19,66 @@
     <title>Application &bci;s</title>
   </info>
   <para>
-    Application &bcia;s are &bcia;-Base container images that include specific
-    applications, such as the PostgreSQL database and the Performance Co-Pilot
-    a system-level performance analysis toolkit. Application &bcia;s are
-    available in the dedicated section of the
-    <link xlink:href="https://registry.suse.com/#apps">&suseregistry;</link>.
+    Application &bcia;s are &bcia;-Base container images that include a
+    specific server, runtime or developer tool, ready to run without any
+    further customization. They are published in the dedicated section of the
+    <link xlink:href="https://registry.suse.com/#apps">&suseregistry;</link>;
+    the list below summarizes the broad categories currently available. The
+    set of published applications evolves continuously, so consult the
+    registry for the authoritative, up-to-date inventory and the support
+    level of each image.
+  </para>
+  <variablelist>
+    <varlistentry>
+      <term>Databases</term>
+      <listitem>
+        <para>
+          Relational and document databases shipped as application images, for
+          example PostgreSQL (including the
+          <literal>postgresql-contrib</literal> variants), MariaDB Server and
+          Client, and Valkey/Redis-compatible key-value stores.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Network infrastructure</term>
+      <listitem>
+        <para>
+          Ready-to-run network services such as the ISC BIND 9 DNS server,
+          the ISC KEA DHCP server, and Samba Server / Client / Toolbox.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Developer and supply-chain tooling</term>
+      <listitem>
+        <para>
+          Command-line tools packaged as standalone containers, including
+          <command>kubectl</command>, Sigstore <command>cosign</command>,
+          <command>crane</command> and <command>ko</command> for container
+          image workflows, and <command>helm</command> for Kubernetes chart
+          deployment.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Observability and management</term>
+      <listitem>
+        <para>
+          System-level analysis and management tooling shipped as
+          ready-to-run images, including Performance Co-Pilot (PCP), the
+          system-level performance analysis toolkit.
+        </para>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+  <para>
+    The above is a non-exhaustive snapshot of the application image catalog.
+    The <link xlink:href="https://registry.suse.com/#apps">Application Images
+    section</link> of the &suseregistry; is the source of truth for which
+    images are currently published, which tags they expose and their support
+    level. New application images are also announced on the
+    <link xlink:href="https://github.com/SUSE/bci/discussions">&bci; project
+    discussions</link>.
   </para>
 </article>

--- a/container-guide/concepts/containers-bci-language.xml
+++ b/container-guide/concepts/containers-bci-language.xml
@@ -154,14 +154,13 @@
     <title>Available versions</title>
     <para>
       The Development Stack &bcia;s ship multiple concurrent versions of each
-      language runtime (for example, a current "stable" tag and one or more
-      previous tags). The set of available tags evolves continuously, with new
-      runtime versions published as they reach stability and older ones
-      reaching end-of-support on their upstream schedule. Always consult
+      language runtime. The set of available tags evolves continuously: new
+      runtime versions are published as they reach stability and older ones
+      reach end-of-support on their upstream schedule. Always consult
       <link xlink:href="https://registry.suse.com">&suseregistry;</link> for
       the currently published tags and their support level, and pin to an
       explicit version tag in production rather than relying on a rolling tag
-      such as <literal>stable</literal> or <literal>latest</literal>.
+      such as <literal>latest</literal>.
     </para>
   </note>
 </article>

--- a/container-guide/concepts/containers-bci-language.xml
+++ b/container-guide/concepts/containers-bci-language.xml
@@ -73,8 +73,13 @@
       <term>ruby</term>
       <listitem>
         <para>
-          A standard development environment based on Ruby 2.5, featuring ruby,
-          gem and bundler as well as git and curl.
+          A standard Ruby development environment featuring
+          <command>ruby</command>, <command>gem</command> and
+          <command>bundler</command> as well as <command>git</command> and
+          <command>curl</command>. The Ruby version is specified by the tag;
+          refer to the
+          <link xlink:href="https://registry.suse.com">&suseregistry;</link>
+          for the currently published versions.
         </para>
       </listitem>
     </varlistentry>
@@ -82,7 +87,8 @@
       <term>rust</term>
       <listitem>
         <para>
-          Ships with the Rust compiler and the Cargo package manager.
+          Ships with the Rust compiler and the Cargo package manager. The Rust
+          version is specified by the tag.
         </para>
       </listitem>
     </varlistentry>
@@ -90,7 +96,21 @@
       <term>golang</term>
       <listitem>
         <para>
-          Ships with the go compiler version specified in the tag.
+          Ships with the <command>go</command> compiler version specified in
+          the tag. A variant linked against OpenSSL
+          (<literal>golang:&lt;version&gt;-openssl</literal>) is also
+          published for workloads that require the system FIPS crypto.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>gcc</term>
+      <listitem>
+        <para>
+          Ships with the GNU Compiler Collection (C, C++, Fortran) and the
+          associated build tooling. Intended as a build-time image for
+          compiling C/C++ sources; pair with a smaller deployment image such
+          as &bcia;-Micro or &bcia;-Nano in a multi-stage build.
         </para>
       </listitem>
     </varlistentry>
@@ -130,4 +150,18 @@
       </listitem>
     </varlistentry>
   </variablelist>
+  <note>
+    <title>Available versions</title>
+    <para>
+      The Development Stack &bcia;s ship multiple concurrent versions of each
+      language runtime (for example, a current "stable" tag and one or more
+      previous tags). The set of available tags evolves continuously, with new
+      runtime versions published as they reach stability and older ones
+      reaching end-of-support on their upstream schedule. Always consult
+      <link xlink:href="https://registry.suse.com">&suseregistry;</link> for
+      the currently published tags and their support level, and pin to an
+      explicit version tag in production rather than relying on a rolling tag
+      such as <literal>stable</literal> or <literal>latest</literal>.
+    </para>
+  </note>
 </article>


### PR DESCRIPTION
### PR creator: Description

Two related refreshes of the language- and application-image chapters
that had drifted out of date with the registry.

**`containers-bci-language.xml` (+/- ~41):**

- Drop the stale "Ruby 2.5" version pin and rephrase the entry
  version-agnostically: the runtime version is whatever the tag
  specifies, refer to `registry.suse.com` for the currently published
  versions.
- Add a dedicated entry for the **`gcc`** stack (GNU Compiler
  Collection, C/C++/Fortran), published as `registry.suse.com/bci/gcc`
  and intended as a build-time image in multi-stage builds (paired
  with a slim runtime such as `bci-micro` or `bci-nano`).
- Mention the **`golang:<version>-openssl`** variant published
  alongside the default `golang` stack for workloads requiring the
  system FIPS crypto.
- Add a closing "Available versions" note pointing readers at
  `registry.suse.com` for the live tag inventory and warning against
  rolling tags (`latest`) in production. The note deliberately does
  *not* mention the internal-only `stable` tag.

**`containers-bci-app.xml` (+/- ~66):**

- Replace the 4-line stub that only mentioned PostgreSQL and
  Performance Co-Pilot with a category-based overview covering:
  - Databases (PostgreSQL incl. contrib variants, MariaDB,
    Valkey/Redis)
  - Network infrastructure (BIND 9, KEA DHCP, Samba)
  - Developer and supply-chain tooling (kubectl, cosign, crane, ko,
    helm)
  - Observability (PCP)
- Explicit about the list being a non-exhaustive snapshot and points
  to the Application Images section of `registry.suse.com` and the
  [SUSE/bci discussions board](https://github.com/SUSE/bci/discussions)
  as the authoritative inventory.

Both files now stay version-agnostic and point at
`registry.suse.com` as the live source of truth, so the guide no
longer needs to be re-edited every time a new runtime version or
application image is published.

### PR creator: Are there any relevant issues/feature requests?

None — community contribution.